### PR TITLE
Allow retaining the original request Host header

### DIFF
--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -136,8 +136,13 @@ function _sendTargetRequest(sourceRequest, sourceResponse, plugins, startTime, c
       target_headers['via'] = via;
     }
 
-    // delete the original host header to let node fill it in for the target request
-    delete target_headers.host;
+    // To avoid breaking backard compatibility, we need to remove the "Host" header unless explicitly told not to
+    const resetHostHeader = config.headers && typeof config.headers.host !== 'undefined' ? config.headers : true;
+
+    if (resetHostHeader === true) {
+      delete target_headers.host;
+    }
+
     // delete the original content-length to let node fill it in for the target request
     if (target_headers['content-length']) {
       delete target_headers['content-length'];

--- a/tests/config.js
+++ b/tests/config.js
@@ -1,0 +1,105 @@
+'use strict'
+
+const _ = require('lodash')
+const assert = require('assert')
+const gatewayService = require('../index')
+const request = require('request')
+const restify = require('restify')
+const should = require('should')
+
+const gatewayPort = 8800
+const port = 3300
+const baseConfig = {
+  edgemicro: {
+    port: gatewayPort,
+    logging: { level: 'info', dir: './tests/log' }
+  },
+  proxies: [
+    { base_path: '/v1', secure: false, url: 'http://localhost:' + port }
+  ]
+}
+
+var gateway
+var server
+
+const startGateway = (config, handler, done) => {
+  server = restify.createServer({});
+
+  server.use(restify.gzipResponse());
+  server.use(restify.bodyParser());
+
+  server.get('/', handler);
+
+  server.listen(port, function() {
+    console.log('%s listening at %s', server.name, server.url)
+
+    gateway = gatewayService(config)
+
+    done()
+  })
+}
+
+describe('test configuration handling', () => {
+  afterEach((done) => {
+    if (gateway) {
+      gateway.stop(() => {})
+    }
+
+    if (server) {
+      server.close()
+    }
+
+    done()
+  })
+
+  describe('headers', () => {
+    describe('host', () => {
+      it('false (default value)', (done) => {
+        startGateway(baseConfig, (req, res, next) => {
+          assert.equal('localhost:' + port, req.headers.host)
+          res.end('OK')
+        }, () => {
+          gateway.start((err) => {
+            assert(!err, err)
+
+            request({
+              method: 'GET',
+              url: 'http://localhost:' + gatewayPort + '/v1'
+            }, (err, r, body) => {
+              assert(!err, err)
+              assert.equal('OK', body)
+              done()
+            })
+          })
+        })
+      })
+
+      it('true', (done) => {
+        var config = _.cloneDeep(baseConfig)
+
+        config.headers = {
+          host: false
+        }
+
+        startGateway(config, (req, res, next) => {
+          console.log(req.headers);
+          assert.equal('localhost:' + gatewayPort, req.headers.host)
+          res.end('OK')
+        }, () => {
+          gateway.start((err) => {
+            assert(!err, err)
+
+            request({
+              method: 'GET',
+              url: 'http://localhost:' + gatewayPort + '/v1'
+            }, (err, r, body) => {
+              assert(!err, err)
+              assert.equal('OK', body)
+              done()
+            })
+          })
+        })
+      })
+    })
+  })
+})

--- a/tests/config.yaml
+++ b/tests/config.yaml
@@ -24,11 +24,12 @@ edgemicro:
     sequence:
       - oauth
 headers:
+  host: true
+  via: true
   x-forwarded-for: true
   x-forwarded-host: true
   x-request-id: true
   x-response-time: true
-  via: true
 oauth:
   allowNoAuthorization: false
   allowInvalidAuthorization: false

--- a/tests/logging.test.js
+++ b/tests/logging.test.js
@@ -3,7 +3,7 @@
 var fs = require('fs');
 var chai = require('chai');
 var expect = chai.expect;
-var should = chai.should();
+var should = require('should');
 var debug = require('debug')('gateway:logging-test');
 
 describe('logging', function() {


### PR DESCRIPTION
Right now the `Host` header is always removed prior to making the target
request.  This commit allows you to alter the behavior using the
`config.headers.host` configuration.  The default value is `true`,
which means set (or reset) the `Host` header.  If set to `false`, it
means do not set (or reset) the `Host` header and the originally
requested `Host` header, if there is one, will be retained when making
the target request.