### PR TITLE
stop replacing double slashes in the query string

### DIFF
--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -151,8 +151,9 @@ function _sendTargetRequest(sourceRequest, sourceResponse, plugins, startTime, c
 
   var target_path =
     proxy.parsedUrl.pathname + reqUrl.pathname.substr(proxy.basePathLength, reqUrl.pathname.length); // strip leading base_path
-  if (reqUrl.search) target_path += reqUrl.search;
-  target_path = target_path.replace(double_slash_regex, '/');
+
+  target_path = target_path.replace(double_slash_regex, '/'); // remove any unintended double slashes
+  target_path += reqUrl.search || ''; // append the search string if necessary
 
   const targetRequestOptions = {
     hostname: proxy.parsedUrl.hostname,


### PR DESCRIPTION
Prior to this change, if your query string had a `//` in it, it would be
replaced with a `/` when generating the proxy target path.  This change
keeps the code in place but makes the string replacement only happen for
the path and not the query string.