### PR TITLE
Fixing bug in lib/plugins-middleware.js that mangles the x-response-time header.

### DIFF
--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -25,7 +25,7 @@ module.exports = function(plugins) {
   const logger = logging.getLogger();
 
   return function(sourceRequest, sourceResponse, next) {
-    const startTime = Date.now;
+    const startTime = Date.now();
     const promises = [];
     const correlation_id = uuid.v1();
     logger.info({ req: sourceRequest, i: correlation_id }, 'sourceRequest');


### PR DESCRIPTION
 Date.now wasn't being used as a function.