### PR TITLE
initial implementation of custom metrics

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -1,0 +1,5 @@
+var Client = require('stats-client');
+
+module.exports.client = function(port) {
+    return new Client(`localhost:${port}`);
+}

--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -43,6 +43,7 @@ module.exports = function(plugins) {
           return next(false);
         }
         if (err) {
+          stats.incrementStatusCount(sourceResponse.statusCode);
           return next(err)
         }
         //get the response

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -9,12 +9,26 @@ const logging = require('./logging');
 const configService = require('./config');
 const stats = require('./stats');
 
-
 var Plugins = function () {
   this.config = configService.get();
+
+  var baseObject = {};
+  if (this.config.edgemicro.metrics) {
+    baseObject = require('./metrics').client(this.config.edgemicro.metrics.port || 8125);
+  }
+  // Merge stats objects to fulfill obligations per documentation, overriding getters/setters
+  Object.keys(stats.getStats()).forEach((field) =>
+      Object.defineProperty(baseObject, field, {
+        get: function () {
+          return stats.getStats()[field];
+        },
+        set: function (newValue) {
+          console.error("Attempt to set properties on `stats` object not permitted");
+          //do nothing, you can't override these for now.
+        }
+      }));
+  this.metrics = baseObject
 };
-
-
 
 /**
  * calls init and returns plugin loaded
@@ -55,7 +69,7 @@ Plugins.prototype.loadPlugin = function (options) {
         tunnel: config.edgemicro.proxy_tunnel
       };
     }
-    middleware = plugin(subconfig, logger, stats);
+    middleware = plugin(subconfig, logger, this.metrics);
     assert(_.isObject(middleware), 'ignoring invalid plugin handlers ' + name);
     middleware.id = name;
     console.info('installed plugin from', name);
@@ -68,4 +82,3 @@ Plugins.prototype.loadPlugin = function (options) {
 exports = module.exports = function () {
   return new Plugins();
 };
-

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "debug": "~2.2.0",
     "lodash": "~3.9.3",
     "request": "~2.69.0",
+    "stats-client": "^1.0.0",
     "uuid": "~2.0.1",
     "winston": "~2.2.0",
     "winston-daily-rotate-file": "~1.0.1"


### PR DESCRIPTION
- Add config option in under edgemicro to enable metrics
- If enabled, during process start, a telegraf instance is started as a docker container
- telegraf config must be located in ~/.edgemicro/tele.config 
- plugin init method receives `stats` object, which is now a statsd client sending metrics to telegraf

Todo:
Refine the way that telegraf is configured (do we add a configuration file path option to EM config?)
