### PR TITLE
Undoing the way EM deletes the content-length header

### DIFF
--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -149,9 +149,9 @@ function _sendTargetRequest(sourceRequest, sourceResponse, plugins, startTime, c
     }
 
     // delete the original content-length to let node fill it in for the target request
-    if (target_headers['content-length']) {
-      delete target_headers['content-length'];
-    }
+    //if (target_headers['content-length']) {
+      //delete target_headers['content-length'];
+    //}
   }
 
   const httpLibrary = proxy.secure ? https : http;


### PR DESCRIPTION
A small PR. Consider it a WIP. 

Currently we always delete the `content-length` header in EM. This forces node to use the `transfer-encoding` header. Since this is deleted before we send the request, but after we go through plugins it isn't possible to set `content-length`. This remedies that error.