### PR TITLE
Use the agent as defined in proxy-middleware.js so we can have keep-alive logic.

### DIFF
--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -188,7 +188,7 @@ function _sendTargetRequest(sourceRequest, sourceResponse, plugins, startTime, c
     path: sourceRequest.targetPath,
     method: sourceRequest.method,
     headers: target_headers, // pass through the modified headers
-    agent: proxy.agent
+    agent: agent
   };
 
   const targetRequest = httpLibrary.request(targetRequestOptions,


### PR DESCRIPTION
Fixes a regression where keep-alive isn't used properly. 

See community post.

https://community.apigee.com/questions/34813/http-keepalive-connections-from-edgemicro-to-targe.html