### PR TITLE
Makes plugin type detection clearer. Provides the targetResponse as an argument.

### DIFF
--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -534,9 +534,23 @@ function _executePluginHandler(plugin, type, options) {
             cb(e, data);
           }
         };
-        plugin['on' + handler](options.sourceRequest, options.sourceResponse,
-          plugin['on' + handler].length === 3 ? fx : data, //if 3 args must be the older style
-          fx)
+
+        var pluginHandler = plugin['on' + handler];
+        var argsLength = pluginHandler.length;
+        var args = null;
+        if(argsLength === 3) {
+          args = [options.sourceRequest, options.sourceResponse, fx];
+        } else if(argsLength == 4) {
+          args = [options.sourceRequest, options.sourceResponse, data, fx];
+        } else if(argsLength == 5) {
+          args = [options.sourceRequest, options.sourceResponse, options.targetResponse, data, fx];
+        }
+
+        pluginHandler.apply(null, args);
+
+        //plugin['on' + handler](options.sourceRequest, options.sourceResponse,
+        //  plugin['on' + handler].length === 3 ? fx : data, //if 3 args must be the older style
+        //  fx)
       } else {
         debug("plugin " + plugin.id + " does not provide handler function for " + handler);
         cb(null, data); // plugin does not provide onerror_request, carry on

--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -523,6 +523,7 @@ function _executePluginHandler(plugin, type, options) {
     try {
 
       const handler = (type ? type + '_' : '') + (isRequest ? 'request' : 'response');
+      console.log('on'+handler);
       if (plugin['on' + handler] && _.isFunction(plugin['on' + handler])) {
         const fx = function(e, newData) {
           //a small fix introduced to fix issues with plugin API being inconsistent with documentation.
@@ -562,7 +563,7 @@ function _executePluginHandler(plugin, type, options) {
 
   }
 };
-
+module.exports._executePluginHandler = _executePluginHandler;
 
 const _configured = function(config, property) {
   if (config.headers) {

--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -523,7 +523,6 @@ function _executePluginHandler(plugin, type, options) {
     try {
 
       const handler = (type ? type + '_' : '') + (isRequest ? 'request' : 'response');
-      console.log('on'+handler);
       if (plugin['on' + handler] && _.isFunction(plugin['on' + handler])) {
         const fx = function(e, newData) {
           //a small fix introduced to fix issues with plugin API being inconsistent with documentation.

--- a/tests/plugins-behavior.js
+++ b/tests/plugins-behavior.js
@@ -1,0 +1,79 @@
+const assert = require('assert');
+const PluginsMiddleware = require('../lib/plugins-middleware');
+
+describe('plugin behavior', () => {
+  it('exposes _executePluginHandler', () => {
+    assert.ok(PluginsMiddleware._executePluginHandler);
+  });
+
+  it('will provide three arguments to in req, res, next format', (done) => {
+    var plugins = {
+      'ondata_request': function(req, res, next) {
+        assert.equal(req, 'foo');
+        assert.equal(res, 'bar');
+        assert.equal(typeof next, 'function');
+        next(null, null);      
+      }
+    }
+
+    var opts = {
+      sourceRequest: 'foo',
+      sourceResponse: 'bar',
+    }
+
+    PluginsMiddleware._executePluginHandler(plugins, 'data', opts)('foo', (arg1, arg2) =>{
+      assert.equal(arg1, null);
+      assert.equal(arg2, null);
+      done(); 
+    });
+  });
+
+  it('will provide three arguments to in req, res, data, next format', (done) => {
+    var plugins = {
+      'ondata_request': function(req, res, data, next) {
+        assert.equal(req, 'foo');
+        assert.equal(res, 'bar');
+        assert.equal(data, 'foo');
+        assert.equal(typeof next, 'function');
+        next(null, null);
+      }
+    }
+
+    var opts = {
+      sourceRequest: 'foo',
+      sourceResponse: 'bar',
+    }
+
+    PluginsMiddleware._executePluginHandler(plugins, 'data', opts)('foo', (arg1, arg2) =>{
+      assert.equal(arg1, null);
+      assert.equal(arg2, null);
+      done(); 
+    });
+  });
+
+  it('will provide three arguments to in req, res, targetRes, data,  next format', (done) => {
+    var plugins = {
+      'ondata_request': function(req, res, targetResponse, data, next) {
+        assert.equal(req, 'foo');
+        assert.equal(res, 'bar');
+        assert.equal(data, 'foo');
+        assert.equal(targetResponse, 'quux');
+        assert.equal(typeof next, 'function');
+        next(null, null); 
+      }
+    }
+
+    var opts = {
+      sourceRequest: 'foo',
+      sourceResponse: 'bar',
+      targetResponse: 'quux',
+    }
+
+    PluginsMiddleware._executePluginHandler(plugins, 'data', opts)('foo', (arg1, arg2) =>{
+      assert.equal(arg1, null);
+      assert.equal(arg2, null);
+      done(); 
+    });
+  
+  });
+});


### PR DESCRIPTION
This is a potential fix for issues where plugins would like access to the targetResponse. 

