### PR TITLE
fixing memory leak which occurs during large request/responses

### DIFF
--- a/lib/ondata-transform.js
+++ b/lib/ondata-transform.js
@@ -1,0 +1,30 @@
+const async = require('async');
+const debug = require('debug')('gateway:main');
+const Transform = require('stream').Transform;
+const util = require('util');
+
+function OnDataTransform(context) {
+  this.pluginHooks = context.pluginHooks;
+  Transform.call(this, { objectMode: false });
+}
+util.inherits(OnDataTransform, Transform);
+
+OnDataTransform.prototype._transform = function (data, encoding, done) {
+  debug('req data', data ? data.length : 'null');
+  var self = this;
+  async.seq.apply(this, self.pluginHooks)(data,
+    function(err, result) {
+      if (err) {
+        console.error(err);
+        done(err);
+      }
+      else {
+        if(result) {
+          self.push(result);
+        }
+        done();
+      }
+    });
+}
+
+module.exports = OnDataTransform;

--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -8,13 +8,12 @@ const uuid = require('uuid');
 const _ = require('lodash');
 const async = require('async');
 const debug = require('debug')('gateway:main');
-const configService = require('./config');
 const logging = require('./logging')
-const double_slash_regex = /\/\/+/g;
-const empty_buffer = new Buffer(0);
 const assert = require('assert');
 const stats = require('./stats')
-
+const OnDataTransform = require('./ondata-transform');
+const configService = require('./config');
+const empty_buffer = new Buffer(0);
 
 /**
  * injects plugins into gateway
@@ -26,14 +25,13 @@ module.exports = function(plugins) {
 
   return function(sourceRequest, sourceResponse, next) {
     const startTime = Date.now();
-    const promises = [];
     const correlation_id = uuid.v1();
     logger.info({ req: sourceRequest, i: correlation_id }, 'sourceRequest');
     debug('sourceRequest', correlation_id, sourceRequest.method, sourceRequest.url);
     //process the requests
     async.series(
       //onrequest
-      _executePluginHandlers(null, {
+      getPluginHooksForEvent(null, {
         plugins: plugins,
         sourceRequest: sourceRequest,
         sourceResponse: sourceResponse
@@ -45,9 +43,11 @@ module.exports = function(plugins) {
         if (err) {
           return next(err)
         }
-        //get the response
-        const targetRequest = _sendTargetRequest(sourceRequest, sourceResponse, plugins, startTime, correlation_id,
+        //create target request
+        const targetRequest = _getTargetRequest(sourceRequest, sourceResponse, plugins, startTime, correlation_id,
+          //callback for when response is initiated
           (err, targetResponse) => {
+
             if (err) {
               return next(err);
             }
@@ -57,19 +57,19 @@ module.exports = function(plugins) {
               plugins: plugins,
               sourceRequest: sourceRequest,
               sourceResponse: sourceResponse,
-              promises: promises
             };
 
             _handleTargetResponse(targetRequest, targetResponse, options, function(err, results) {
               if (err) {
                 next(err);
               }
-              sourceResponse.end(results);
-              next();
+              else {
+                next();
+              }
             })
           });
-
-        _subscribeToSourceRequestEvents(plugins, promises, sourceRequest, sourceResponse, targetRequest);
+        //initiate request piping
+        _subscribeToSourceRequestEvents(plugins, sourceRequest, sourceResponse, targetRequest);
         targetRequest.on('close', function() {
           debug('sourceRequest close');
         });
@@ -78,7 +78,7 @@ module.exports = function(plugins) {
 };
 
 /**
- * call the target server to send the source request
+ * Create the target request
  * @param plugins
  * @param correlation_id
  * @param sourceRequest
@@ -86,12 +86,11 @@ module.exports = function(plugins) {
  * @param cb
  * @private
  */
-function _sendTargetRequest(sourceRequest, sourceResponse, plugins, startTime, correlation_id, cb) {
+function _getTargetRequest(sourceRequest, sourceResponse, plugins, startTime, correlation_id, cb) {
 
   const logger = logging.getLogger();
   const config = configService.get();
 
-  const reqUrl = sourceRequest.reqUrl;
   const proxy = sourceResponse.proxy;
 
   // try to pass through most of the original request headers unmodified
@@ -147,21 +146,14 @@ function _sendTargetRequest(sourceRequest, sourceResponse, plugins, startTime, c
     if (resetHostHeader === true) {
       delete target_headers.host;
     }
-
     // delete the original content-length to let node fill it in for the target request
     if (target_headers['content-length']) {
       delete target_headers['content-length'];
     }
-    
   }
 
   const httpLibrary = proxy.secure ? https : http;
   assert(httpLibrary.request, 'must have request method');
-
-  var agentOptions = {
-    maxSockets: limit(proxy.max_connections), // limit target connections
-    keepAlive: true
-  };
 
   if (proxy.secure && Array.isArray(config.targets)) {
     var filtered = config.targets.filter(function(target) {
@@ -176,12 +168,9 @@ function _sendTargetRequest(sourceRequest, sourceResponse, plugins, startTime, c
       var lastIndex = filtered.length - 1;
       var last = filtered[lastIndex]
       var httpsOptions = last.ssl.client.httpsOptions;
-      agentOptions = _.merge(agentOptions, httpsOptions);
     }
     // check for client ssl options
   }
-
-  //var agent = new httpLibrary.Agent(agentOptions);
 
   const targetRequestOptions = {
     hostname: sourceRequest.targetHostname,
@@ -192,13 +181,8 @@ function _sendTargetRequest(sourceRequest, sourceResponse, plugins, startTime, c
     agent: proxy.agent
   };
 
-
   const targetRequest = httpLibrary.request(targetRequestOptions,
-    (targetResponse) => {
-
-      cb(null, targetResponse);
-
-    });
+    (targetResponse) => cb(null, targetResponse));
 
   targetRequest.on('error', function(err) {
     const logInfo = {
@@ -209,11 +193,11 @@ function _sendTargetRequest(sourceRequest, sourceResponse, plugins, startTime, c
     };
     logger.warn({ req: logInfo, d: Date.now() - startTime, i: correlation_id, err: err }, 'targetRequest error');
     debug('targetRequest error', correlation_id, err.stack);
-    async.series(_executePluginHandlers('error', {
-      plugins: plugins,
-      sourceRequest: sourceRequest,
-      sourceResponse: sourceResponse
-    }),
+    async.series(getPluginHooksForEvent('error', {
+        plugins: plugins,
+        sourceRequest: sourceRequest,
+        sourceResponse: sourceResponse
+      }),
       function(e) {
         if (e) {
           logger.error(e);
@@ -236,13 +220,11 @@ function _sendTargetRequest(sourceRequest, sourceResponse, plugins, startTime, c
 
   debug('targetRequest', correlation_id, targetRequestOptions.method, targetRequestOptions.hostname, targetRequestOptions.port, targetRequestOptions.path);
   stats.incrementRequestCount();
-
   return targetRequest;
-
 };
 
 /**
- *
+ * Handle the plugin wiring and response piping
  * @param targetRequest
  * @param targetResponse
  * @param options {start, correlation_id, plugins, sourceRequest, sourceResponse,promises}
@@ -257,223 +239,135 @@ function _handleTargetResponse(targetRequest, targetResponse, options, cb) {
   const sourceResponse = options.sourceResponse;
   const logger = logging.getLogger();
   const config = configService.get();
-  const promises = options.promises;
 
   logger.info({ res: targetResponse, d: Date.now() - start, i: correlation_id }, 'targetResponse');
   debug('targetResponse', correlation_id, targetResponse.statusCode);
-  const promise = new Promise(function(resolve, reject) {
-    async.series(
-      //onresponse
-      _executePluginHandlers(null, {
-        plugins: plugins,
-        sourceRequest: sourceRequest,
-        sourceResponse: sourceResponse,
-        targetRequest: targetRequest,
-        targetResponse: targetResponse
-      }),
-      function(err, results) {
-        err && logger.error(err);
-        if (sourceResponse.finished || sourceResponse.headersSent) {
-          logger.error("response finished before work can be done");
-          reject("response finished before work can be done");
-          return;
+  async.series(
+    //onresponse
+    getPluginHooksForEvent(null, {
+      plugins: plugins,
+      sourceRequest: sourceRequest,
+      sourceResponse: sourceResponse,
+      targetRequest: targetRequest,
+      targetResponse: targetResponse
+    }),
+    function(err, results) {
+      err && logger.error(err);
+      if (sourceResponse.finished || sourceResponse.headersSent) {
+        logger.error("response finished before work can be done");
+        return;
+      }
+      if (err) {
+        return cb(err);
+      }
+      debug(results);
+      stats.incrementStatusCount(targetResponse.statusCode);
+      stats.incrementResponseCount();
+      // the size of the body will change if any of the plugins transform the content
+      // delete the response content-length to allow streaming.
+      delete targetResponse.headers['content-length'];
+      // propagate response headers from target to client
+      Object.keys(targetResponse.headers).forEach(function(header) {
+        // skip setting the 'connection: keep-alive' header
+        // setting it causes gateway to not accept any more connections
+        if (header !== 'connection') {
+          sourceResponse.setHeader(header, targetResponse.headers[header]);
         }
+      });
+      sourceResponse.statusCode = targetResponse.statusCode;
 
-        if (err) {
-          return reject(err);
-        }
-
-        debug(results);
-        stats.incrementStatusCount(targetResponse.statusCode);
-        stats.incrementResponseCount();
-        // the size of the body will change if any of the plugins transform the content
-        // delete the response content-length and let node recalculate it for the client request
-        delete targetResponse.headers['content-length'];
-        // propagate response headers from target to client
-        Object.keys(targetResponse.headers).forEach(function(header) {
-          // skip setting the 'connection: keep-alive' header
-          // setting it causes gateway to not accept any more connections
-          if (header !== 'connection') {
-            sourceResponse.setHeader(header, targetResponse.headers[header]);
-          }
+      if (_configured(config, 'x-response-time')) {
+        sourceResponse.setHeader('x-response-time', Date.now() - start);
+      }
+      _subscribeToResponseEvents(plugins, sourceRequest, sourceResponse, targetRequest, targetResponse, correlation_id, start,
+        function(err, result) {
+          cb(err, result)
         });
-        sourceResponse.statusCode = targetResponse.statusCode;
+    });
+};
 
-        if (_configured(config, 'x-response-time')) {
-          sourceResponse.setHeader('x-response-time', Date.now() - start);
-        }
-        resolve();
+/**
+ * Properly set up request piping.
+ * @param plugins
+ * @param sourceRequest
+ * @param sourceResponse
+ * @param targetRequest
+ * @private
+ */
+function _subscribeToSourceRequestEvents(plugins, sourceRequest, sourceResponse, targetRequest) {
+  const logger = logging.getLogger();
+  console.log('subscribing to source data request events');
 
+  const onend_request_handlers = async.seq.apply(this, getPluginHooksForEvent('end', {
+    plugins: plugins,
+    sourceRequest: sourceRequest,
+    sourceResponse: sourceResponse,
+  }));
+
+  var ondata_request_transform = new OnDataTransform({
+    pluginHooks: getPluginHooksForEvent('data', {
+      plugins: plugins,
+      sourceRequest: sourceRequest,
+      sourceResponse: sourceResponse
+    })
+  })
+
+  sourceRequest.on('end', ()=> {
+    onend_request_handlers(empty_buffer,
+      function(err, result) {
+        err ? logger.error(err) : (result && targetRequest.write(result));
+        return err;
       });
   });
-  promises.push(promise);
-  _subscribeToResponseEvents(plugins, promises, sourceRequest, sourceResponse, targetRequest, targetResponse, correlation_id, start,
-    function(err, result) {
-      cb(err, result)
-    });
 
+  sourceRequest
+    .pipe(ondata_request_transform)
+    .pipe(targetRequest);
 };
 
-function _subscribeToSourceRequestEvents(plugins, promises, sourceRequest, sourceResponse, targetRequest) {
+/**
+ * Properly set up response piping.
+ * @param plugins
+ * @param sourceRequest
+ * @param sourceResponse
+ * @param targetRequest
+ * @param targetResponse
+ * @param correlation_id
+ * @param start
+ * @param cb
+ * @private
+ */
+function _subscribeToResponseEvents(plugins, sourceRequest, sourceResponse, targetRequest, targetResponse, correlation_id, start, cb) {
   const logger = logging.getLogger();
-  // write body
-  sourceRequest.on('data', function(data) {
-    const promise = new Promise((resolve, reject) => {
-      debug('req data', data ? data.length : 'null');
-      async.seq.apply(this,
-        _executePluginHandlers('data', {
-          plugins: plugins,
-          sourceRequest: sourceRequest,
-          sourceResponse: sourceResponse
-        }))(data,
-        function(err, result) {
-          if (err) {
-            logger.error(err);
-            return reject(err);
-          }
+  const onend_response_handlers = async.seq.apply(this, getPluginHooksForEvent('end', {
+    plugins: plugins,
+    sourceRequest: sourceRequest,
+    sourceResponse: sourceResponse,
+    targetRequest: targetRequest,
+    targetResponse: targetResponse
+  }));
 
-          if(result) {
-            targetRequest.write(result); // write transformed data to target
-          }
-          resolve();
-        });
-    });
-    promises.push(promise);
-
+  var ondata_response_transform = new OnDataTransform({
+    pluginHooks: getPluginHooksForEvent('data', {
+      plugins: plugins,
+      sourceRequest: sourceRequest,
+      sourceResponse: sourceResponse,
+      targetRequest: targetRequest,
+      targetResponse: targetResponse
+    })
   });
 
-  sourceRequest.on('end', function() {
-    const promisesBefore = promises.slice();
-    const promise = new Promise((resolve, reject) => {
-
-      Promise.all(promisesBefore)
-        .then(
-        () => { //resolve
-          debug('req end');
-          async.seq.apply(this, _executePluginHandlers('end', {
-            plugins: plugins,
-            sourceRequest: sourceRequest,
-            sourceResponse: sourceResponse
-          }))(empty_buffer,
-            function(err, result) {
-              if (err) {
-                logger.error(err);
-                return reject(err);
-              }
-              
-              if(!targetRequest._headerSent) {
-                Object.keys(sourceRequest._overrideHeaders).forEach(function(k) {
-                  var value = sourceRequest._overrideHeaders[k];
-                  targetRequest.setHeader(k, value);
-                });                
-
-                sourceRequest._headersToUnset.forEach(function(h) {
-                  targetRequest.unsetHeader(h);
-                });
-              }
-
-              targetRequest.end(result); // write transformed data to target
-              resolve();
-            });
-        },
-        (err) => { //reject
-          reason && logger.error(err);
-          reject(err)
-        })
-        .catch((err) => {
-          logger.error(err, 'all promises were rejected')
-          reject(err)
-        })
-    });
-    promises.push(promise);
-
+  targetResponse.on('end', ()=> {
+    onend_response_handlers(empty_buffer,
+      function(err, result) {
+        err ? logger.error(err) : (result && sourceResponse.write(result));
+        cb(err, result);
+      });
   });
 
-  return promises;
-};
-
-function _subscribeToResponseEvents(plugins, promises, sourceRequest, sourceResponse, targetRequest, targetResponse, correlation_id, start, cb) {
-  const logger = logging.getLogger();
-  const resolved = false;
-  targetResponse.on('data', function(data) {
-
-    const promisesBefore = promises.slice();
-    const promise = new Promise(function(resolve, reject) {
-
-      Promise.all(promisesBefore)
-        .then(
-        () => { //resolve
-          if (data && !sourceResponse.finished) {
-            async.seq.apply(this, _executePluginHandlers('data', {
-              plugins: plugins,
-              sourceRequest: sourceRequest,
-              sourceResponse: sourceResponse,
-              targetRequest: targetRequest,
-              targetResponse: targetResponse
-            }))(data,
-              function(err, result) {
-                err && logger.error(err);
-                if (err) {
-                  return reject(err);
-                }
-                if (result) {
-                  sourceResponse.write(result);
-                  !resolved && resolve();
-                } // write transformed data to response
-                else {
-                  !resolved && resolve();
-                }
-              });
-          } else {
-            if (data) {
-              logger.warn({ res: targetResponse, i: correlation_id }, 'discarding data received after response sent');
-            }
-            resolve();
-          }
-        },
-        (err) => { //reject
-          err && logger.error(err);
-          reject(err)
-        })
-        .catch((err) => {
-          logger.error(err, 'all promises were rejected')
-          reject(err)
-        })
-
-    });
-    promises.push(promise)
-  });
-
-
-  targetResponse.on('end', function() {
-    Promise.all(promises)
-      .then(
-      () => { //resolve
-        logger.info({ res: sourceResponse, d: Date.now() - start, i: correlation_id }, 'res');
-        debug('targetResponse end', correlation_id, targetResponse.statusCode);
-        async.seq.apply(this, _executePluginHandlers('end', {
-          plugins: plugins,
-          sourceRequest: sourceRequest,
-          sourceResponse: sourceResponse,
-          targetRequest: targetRequest,
-          targetResponse: targetResponse
-        }))(
-          empty_buffer,
-          function(err, result) {
-            err && logger.error(err);
-            cb(err, result)
-          });
-      },
-      (err) => { //reject
-        err && logger.error(err);
-        cb(err);
-      })
-      .catch((err) => {
-        logger.error(err, 'all promises were rejected')
-        cb(err);
-      })
-
-  });
+  targetResponse
+    .pipe(ondata_response_transform)
+    .pipe(sourceResponse);
 
   targetResponse.on('close', function() {
     debug('targetResponse close', correlation_id);
@@ -481,39 +375,34 @@ function _subscribeToResponseEvents(plugins, promises, sourceRequest, sourceResp
   });
 
   targetResponse.on('error', function(err) {
-    const promise = new Promise(function(resolve, reject) {
+    logger.warn({
+      res: targetResponse,
+      d: Date.now() - start,
+      i: correlation_id,
+      err: err
+    }, 'targetResponse error');
 
-      logger.warn({
-        res: targetResponse,
-        d: Date.now() - start,
-        i: correlation_id,
-        err: err
-      }, 'targetResponse error');
-
-      debug('targetResponse error', correlation_id, err.stack);
-      async.series(_executePluginHandlers('error', {
+    debug('targetResponse error', correlation_id, err.stack);
+    async.series(getPluginHooksForEvent('error', {
         plugins: plugins,
         sourceRequest: sourceRequest,
         sourceResponse: sourceResponse,
         targetRequest: targetRequest,
         targetResponse: targetResponse
       }),
-        function(e) {
-          const error = e || err;
-          reject(error);
-        });
-    });
-    promises.push(promise);
+      function(err) {
+        cb(err)
+      });
   });
 }
 
-const _executePluginHandlers = function(type, options) {
+const getPluginHooksForEvent = function(type, options) {
   const plugins = options.plugins;
-  const pluginMap = plugins.map((plugin) => _executePluginHandler(plugin, type, options));
+  const pluginMap = plugins.map((plugin) => getPluginHookForEvent(plugin, type, options));
   return pluginMap;
 };
 
-function _executePluginHandler(plugin, type, options) {
+function getPluginHookForEvent(plugin, type, options) {
   const isRequest = !options.targetRequest;
   const logger = logging.getLogger();
   //return handler
@@ -547,10 +436,6 @@ function _executePluginHandler(plugin, type, options) {
         }
 
         pluginHandler.apply(null, args);
-
-        //plugin['on' + handler](options.sourceRequest, options.sourceResponse,
-        //  plugin['on' + handler].length === 3 ? fx : data, //if 3 args must be the older style
-        //  fx)
       } else {
         debug("plugin " + plugin.id + " does not provide handler function for " + handler);
         cb(null, data); // plugin does not provide onerror_request, carry on
@@ -562,7 +447,7 @@ function _executePluginHandler(plugin, type, options) {
 
   }
 };
-module.exports._executePluginHandler = _executePluginHandler;
+module.exports._executePluginHandler = getPluginHookForEvent;
 
 const _configured = function(config, property) {
   if (config.headers) {

--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -431,7 +431,7 @@ function getPluginHookForEvent(plugin, type, options) {
 
   }
 };
-module.exports._executePluginHandler = getPluginHookForEvent;
+module.exports.getPluginHookForEvent = getPluginHookForEvent;
 
 const _configured = function(config, property) {
   if (config.headers) {

--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -43,8 +43,9 @@ module.exports = function(plugins) {
         if (err) {
           return next(err)
         }
+
         //create target request
-        const targetRequest = _getTargetRequest(sourceRequest, sourceResponse, plugins, startTime, correlation_id,
+        const targetRequest = getTargetRequest(sourceRequest, sourceResponse, plugins, startTime, correlation_id,
           //callback for when response is initiated
           (err, targetResponse) => {
 
@@ -59,7 +60,7 @@ module.exports = function(plugins) {
               sourceResponse: sourceResponse,
             };
 
-            _handleTargetResponse(targetRequest, targetResponse, options, function(err, results) {
+            handleTargetResponse(targetRequest, targetResponse, options, function(err) {
               if (err) {
                 next(err);
               }
@@ -68,8 +69,9 @@ module.exports = function(plugins) {
               }
             })
           });
+
         //initiate request piping
-        _subscribeToSourceRequestEvents(plugins, sourceRequest, sourceResponse, targetRequest);
+        subscribeToSourceRequestEvents(plugins, sourceRequest, sourceResponse, targetRequest);
         targetRequest.on('close', function() {
           debug('sourceRequest close');
         });
@@ -86,7 +88,7 @@ module.exports = function(plugins) {
  * @param cb
  * @private
  */
-function _getTargetRequest(sourceRequest, sourceResponse, plugins, startTime, correlation_id, cb) {
+function getTargetRequest(sourceRequest, sourceResponse, plugins, startTime, correlation_id, cb) {
 
   const logger = logging.getLogger();
   const config = configService.get();
@@ -146,7 +148,7 @@ function _getTargetRequest(sourceRequest, sourceResponse, plugins, startTime, co
     if (resetHostHeader === true) {
       delete target_headers.host;
     }
-    // delete the original content-length to let node fill it in for the target request
+
     if (target_headers['content-length']) {
       delete target_headers['content-length'];
     }
@@ -154,23 +156,6 @@ function _getTargetRequest(sourceRequest, sourceResponse, plugins, startTime, co
 
   const httpLibrary = proxy.secure ? https : http;
   assert(httpLibrary.request, 'must have request method');
-
-  if (proxy.secure && Array.isArray(config.targets)) {
-    var filtered = config.targets.filter(function(target) {
-      var hostname = proxy.parsedUrl.hostname;
-      return target.host === hostname
-        && typeof target.ssl === 'object'
-        && typeof target.ssl.client === 'object';
-    });
-
-    if (filtered.length) {
-      // get SSL options from the last client object
-      var lastIndex = filtered.length - 1;
-      var last = filtered[lastIndex]
-      var httpsOptions = last.ssl.client.httpsOptions;
-    }
-    // check for client ssl options
-  }
 
   const targetRequestOptions = {
     hostname: sourceRequest.targetHostname,
@@ -231,7 +216,7 @@ function _getTargetRequest(sourceRequest, sourceResponse, plugins, startTime, co
  * @param cb
  * @private
  */
-function _handleTargetResponse(targetRequest, targetResponse, options, cb) {
+function handleTargetResponse(targetRequest, targetResponse, options, cb) {
   const start = options.start;
   const correlation_id = options.correlation_id;
   const plugins = options.plugins;
@@ -294,7 +279,7 @@ function _handleTargetResponse(targetRequest, targetResponse, options, cb) {
  * @param targetRequest
  * @private
  */
-function _subscribeToSourceRequestEvents(plugins, sourceRequest, sourceResponse, targetRequest) {
+function subscribeToSourceRequestEvents(plugins, sourceRequest, sourceResponse, targetRequest) {
   const logger = logging.getLogger();
   console.log('subscribing to source data request events');
 
@@ -457,8 +442,3 @@ const _configured = function(config, property) {
     return true; // on if no config.headers section
   }
 };
-
-function limit(value) {
-  // use value if configured, numeric and positive, otherwise unlimited
-  return value && typeof value === 'number' && value > 0 ? value : Infinity;
-}

--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -299,7 +299,7 @@ function subscribeToSourceRequestEvents(plugins, sourceRequest, sourceResponse, 
   sourceRequest.on('end', ()=> {
     onend_request_handlers(empty_buffer,
       function(err, result) {
-        err ? logger.error(err) : (result && targetRequest.write(result));
+        err ? logger.error(err) : (result.length && targetRequest.write(result));
         return err;
       });
   });
@@ -344,7 +344,7 @@ function _subscribeToResponseEvents(plugins, sourceRequest, sourceResponse, targ
   targetResponse.on('end', ()=> {
     onend_response_handlers(empty_buffer,
       function(err, result) {
-        err ? logger.error(err) : (result && sourceResponse.write(result));
+        err ? logger.error(err) : (result.length && sourceResponse.write(result));
         cb(err, result);
       });
   });

--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -281,7 +281,6 @@ function handleTargetResponse(targetRequest, targetResponse, options, cb) {
  */
 function subscribeToSourceRequestEvents(plugins, sourceRequest, sourceResponse, targetRequest) {
   const logger = logging.getLogger();
-  console.log('subscribing to source data request events');
 
   const onend_request_handlers = async.seq.apply(this, getPluginHooksForEvent('end', {
     plugins: plugins,

--- a/tests/plugin-lifecycle.js
+++ b/tests/plugin-lifecycle.js
@@ -14,24 +14,24 @@ describe('test lifecycle events', function() {
   var config = {};
   var gateway;
   var bodyMap = {
-    get: { "get": "gettest" },
-    post: { "post": "posttest" },
-    put: { "put": "puttest" },
-    delete: { "delete": "deletetest" }
+    get: {"get": "gettest"},
+    post: {"post": "posttest"},
+    put: {"put": "puttest"},
+    delete: {"delete": "deletetest"}
 
   }
   var server = serverFactory(bodyMap);
   config = {
     edgemicro: {
       port: gatewayPort,
-      logging: { level: 'info', dir: './tests/log' }
+      logging: {level: 'info', dir: './tests/log'}
     },
     proxies: [
-      { base_path: '/v1', secure: false, url: 'http://localhost:' + port }
+      {base_path: '/v1', secure: false, url: 'http://localhost:' + port}
     ]
   };
-  beforeEach(function(done) {
-    server.listen(port, function() {
+  beforeEach(function (done) {
+    server.listen(port, function () {
       console.log('%s listening at %s', server.name, server.url);
       gateway = gatewayService(config);
       done();
@@ -39,56 +39,34 @@ describe('test lifecycle events', function() {
 
 
   });
-  afterEach(function(done) {
+  afterEach(function (done) {
     gateway && gateway.stop(() => {
     });
     server.close();
     done();
   })
 
-  it('call promises', function(done) {
-    var j = 0;
-    const p = new Promise(function(resolve, reject) {
-      resolve(j++);
-    });
-    var doned = false;
-    for (var i = 0; i < 10; i++) {
-      p.then(function(m) {
-        assert(m == 0);
-        if (i == 10 && !doned) {
-          doned = true;
-          done();
-        }
-      })
-      process.nextTick(function() {
-      });
-    }
-  });
-  it('POST lifecycle all events run', function(done) {
+  it('POST lifecycle all events run', function (done) {
     this.timeout(20000);
     var expectedTypes = ['ondata_request', 'onrequest', 'onend_request', 'onresponse', 'ondata_response', 'onend_response'];
     var types = {};
-    var startMs = 500;
-    var testPlugin = TestPlugin(function(type, data, cb) {
-      startMs = startMs - 50;
-      setTimeout(() => {
-        types[type] = data;
-        cb();
-      }, startMs);
-
+    var testPlugin = TestPlugin(function (type, data, cb) {
+      types[type] = true;
+      cb();
     });
     var handler = testPlugin.init();
-    gateway.addPlugin('test', function test() { return handler });
-    gateway.start(function(err) {
+    gateway.addPlugin('test', function test() {
+      return handler
+    });
+    gateway.start(function (err) {
       assert(!err, err);
       request({
         method: "POST",
         url: 'http://localhost:' + gatewayPort + '/v1/echo/post',
-        json: { "test": "123" }
+        json: {"test": "123"}
       }, (err, r, body) => {
         assert(!err, err);
-        assert.deepEqual(body, { "post": bodyMap['post'], body: { "test": "123" } });//confirm echo and body are returned
-
+        assert.deepEqual(body, {"post": bodyMap['post'], body: {"test": "123"}});//confirm echo and body are returned
         var keys = Object.keys(types);
         assert.deepEqual(keys.sort(), expectedTypes.sort());
         done();
@@ -100,23 +78,12 @@ describe('test lifecycle events', function() {
     this.timeout(20000);
     var expectedTypes = ['ondata_request', 'onrequest', 'onend_request', 'onresponse', 'ondata_response', 'onend_response'];
     var types = {};
-    var startMs = 1000;
     var testPlugin = TestPlugin(function(type, data, cb, req, res) {
-      startMs = startMs - 200;
-      setTimeout(() => {
-        types[type] = data;
-        if (type === 'ondata_response') {
-          // var json = JSON.parse(data);
-          // console.log(json);
-
-          // console.log(testPlugin.expectedHeaders)
-        }
-        assert.equal(
-          _findHeaders(res.headers(), testPlugin.expectedHeaders).length, testPlugin.expectedHeaders.length
-        );
-        cb();
-      }, startMs);
-
+      types[type] = true;
+      assert.equal(
+        _findHeaders(res.headers(), testPlugin.expectedHeaders).length, testPlugin.expectedHeaders.length
+      );
+      cb();
     });
     var handler = testPlugin.init();
     gateway.addPlugin('test', function test() { return handler });
@@ -129,7 +96,6 @@ describe('test lifecycle events', function() {
       }, (err, r, body) => {
         assert(!err, body);
         assert.deepEqual(body, { "post": bodyMap['post'], body: { "test": "123" } });//confirm echo and body are returned
-
         var keys = Object.keys(types);
         assert.deepEqual(keys.sort(), expectedTypes.sort());
         done();
@@ -137,19 +103,13 @@ describe('test lifecycle events', function() {
     });
   });
 
-
   it('GET lifecycle all events run', function(done) {
     this.timeout(20000);
     var expectedTypes = ['onrequest', 'onend_request', 'onresponse', 'ondata_response', 'onend_response'];
     var types = {};
-    var startMs = 1000;
     var testPlugin = TestPlugin(function(type, data, cb) {
-      startMs = startMs - 200;
-      setTimeout(() => {
-        types[type] = data;
-        cb();
-      }, startMs);
-
+      types[type] = data;
+      cb();
     });
     var handler = testPlugin.init();
     gateway.addPlugin('test', function test() { return handler });
@@ -158,7 +118,6 @@ describe('test lifecycle events', function() {
       request({ method: "GET", url: 'http://localhost:' + gatewayPort + '/v1/echo/get', json: true }, (err, r, body) => {
         assert(!err, body);
         assert.deepEqual(body, { "get": bodyMap['get'] });//confirm echo and body are returned
-
         var keys = Object.keys(types);
         assert.deepEqual(keys.sort(), expectedTypes.sort());
         done();
@@ -170,14 +129,9 @@ describe('test lifecycle events', function() {
     this.timeout(20000);
     var expectedTypes = ['ondata_request', 'onrequest', 'onend_request', 'onresponse', 'ondata_response', 'onend_response'];
     var types = {};
-    var startMs = 1000;
     var testPlugin = TestPlugin(function(type, data, cb) {
-      startMs = startMs - 200;
-      setTimeout(() => {
-        types[type] = data;
-        cb();
-      }, startMs);
-
+      types[type] = data;
+      cb();
     });
     var handler = testPlugin.init()
     gateway.addPlugin('test', function test() { return handler });
@@ -198,22 +152,16 @@ describe('test lifecycle events', function() {
     });
   });
 
-
   it('POST lifecycle terminate on response', function(done) {
     this.timeout(20000);
     var expectedTypes = ['ondata_request', 'onrequest', 'onend_request', 'onresponse'];
     var types = {};
-    var startMs = 1000;
     var testPlugin = TestPlugin(function(type, data, cb) {
-      startMs = startMs - 200;
-      setTimeout(() => {
-        types[type] = data;
-        if (type === "onresponse") {
+      types[type] = data;
+      if (type === "onresponse") {
 
-        }
-        cb();
-      }, startMs);
-
+      }
+      cb();
     });
     var handler = testPlugin.init()
 
@@ -253,15 +201,9 @@ describe('test lifecycle events', function() {
     this.timeout(20000);
     var expectedTypes = ['ondata_request', 'onrequest', 'onend_request', 'onresponse'];
     var types = {};
-    var startMs = 1000;
     var testPlugin = TestPlugin(function(type, data, cb) {
-      startMs = startMs - 200;
-      setTimeout(() => {
-        types[type] = data;
-
-        cb();
-      }, startMs);
-
+      types[type] = data;
+      cb();
     });
     var handler = testPlugin.init()
 
@@ -296,14 +238,9 @@ describe('test lifecycle events', function() {
     this.timeout(20000);
     var expectedTypes = ['ondata_request', 'onrequest', 'onend_request', 'onresponse'];
     var types = {};
-    var startMs = 1000;
     var testPlugin = TestPlugin(function(type, data, cb) {
-      startMs = startMs - 200;
-      setTimeout(() => {
-        types[type] = data;
-        cb();
-      }, startMs);
-
+      types[type] = data;
+      cb();
     });
     var handler = testPlugin.init()
 
@@ -335,16 +272,11 @@ describe('test lifecycle events', function() {
 
   it('server died should have an error', function(done) {
     this.timeout(20000);
-    var expectedTypes = ['onerror_request', 'onrequest'];
+    var expectedTypes = ['onrequest', 'ondata_request', 'onerror_request', 'onend_request'];
     var types = {};
-    var startMs = 1000;
     var testPlugin = TestPlugin(function(type, data, cb) {
-      startMs = startMs - 200;
-      setTimeout(() => {
-        types[type] = data;
-        cb();
-      }, startMs);
-
+      types[type] = data;
+      cb();
     });
     var handler = testPlugin.init()
     server.close(() => {
@@ -366,9 +298,7 @@ describe('test lifecycle events', function() {
         });
       });
     });
-
   });
-
 });
 
 function _findHeaders(headers, expectedHeaders) {

--- a/tests/plugins-behavior.js
+++ b/tests/plugins-behavior.js
@@ -3,7 +3,7 @@ const PluginsMiddleware = require('../lib/plugins-middleware');
 
 describe('plugin behavior', () => {
   it('exposes getPluginHookForEvent', () => {
-    assert.ok(PluginsMiddleware._executePluginHandler);
+    assert.ok(PluginsMiddleware.getPluginHookForEvent);
   });
 
   it('will provide three arguments to in req, res, next format', (done) => {
@@ -21,7 +21,7 @@ describe('plugin behavior', () => {
       sourceResponse: 'bar',
     }
 
-    PluginsMiddleware._executePluginHandler(plugins, 'data', opts)('foo', (arg1, arg2) =>{
+    PluginsMiddleware.getPluginHookForEvent(plugins, 'data', opts)('foo', (arg1, arg2) =>{
       assert.equal(arg1, null);
       assert.equal(arg2, null);
       done(); 
@@ -44,7 +44,7 @@ describe('plugin behavior', () => {
       sourceResponse: 'bar',
     }
 
-    PluginsMiddleware._executePluginHandler(plugins, 'data', opts)('foo', (arg1, arg2) =>{
+    PluginsMiddleware.getPluginHookForEvent(plugins, 'data', opts)('foo', (arg1, arg2) =>{
       assert.equal(arg1, null);
       assert.equal(arg2, null);
       done(); 
@@ -69,7 +69,7 @@ describe('plugin behavior', () => {
       targetResponse: 'quux',
     }
 
-    PluginsMiddleware._executePluginHandler(plugins, 'data', opts)('foo', (arg1, arg2) =>{
+    PluginsMiddleware.getPluginHookForEvent(plugins, 'data', opts)('foo', (arg1, arg2) =>{
       assert.equal(arg1, null);
       assert.equal(arg2, null);
       done(); 

--- a/tests/plugins-behavior.js
+++ b/tests/plugins-behavior.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const PluginsMiddleware = require('../lib/plugins-middleware');
 
 describe('plugin behavior', () => {
-  it('exposes _executePluginHandler', () => {
+  it('exposes getPluginHookForEvent', () => {
     assert.ok(PluginsMiddleware._executePluginHandler);
   });
 

--- a/tests/testPlugin.js
+++ b/tests/testPlugin.js
@@ -36,58 +36,28 @@ TestPlugin.prototype.init = function myPlugin1() {
         next(null, data);
       }, req, res)
     },
-
-    onclose_request: function (req, res, data, next) {
-      cb('onclose_request', data, function () {
-
-
-        next();
-      }, req, res)
-    },
-    onclose_response: function (req, res, data, next) {
-      cb('onclose_response', data, function () {
-        res.setHeader("x-onclose_response-visited", 'true');
-        headers.push("x-onclose_response-visited");
-
-        next();
-      }, req, res)
-    },
     ondata_request: function (req, res, data, next) {
       cb('ondata_request', data, function () {
-        res.setHeader("x-ondata_request-visited", 'true');
-        headers.push("x-ondata_request-visited");
-        next();
+        next(null, data);
       }, req, res)
     },
     ondata_response: function (req, res, data, next) {
       cb('ondata_response', data, function () {
-        res.setHeader("x-ondata_response-visited", 'true');
-        headers.push("x-ondata_response-visited");
-
         next(null, data);
       }, req, res)
     },
     onend_request: function (req, res, data, next) {
       cb('onend_request', data, function () {
-        res.setHeader("x-onend_request-visited", 'true');
-        headers.push("x-onend_request-visited");
-
-        next();
+        next(null, data);
       }, req, res)
     },
     onend_response: function (req, res, data, next) {
       cb('onend_response', data, function () {
-        !res.headersSent && res.setHeader("x-onend_response-visited", 'true');
-        headers.push("x-onend_response-visited");
-
-        next();
+        next(null, data);
       }, req, res)
     },
     onerror_request: function (req, res, data, next) {
       cb('onerror_request', data, function () {
-        res.setHeader("x-onerror_request-visited", 'true');
-        headers.push("x-onerror_request-visited");
-
         next();
       }, req, res)
     },


### PR DESCRIPTION
use native node streams/piping instead of hacking around with promises.  The previous implementation represented a memory leak during the duration of large requests.  This fixes that, and simplifies the core middleware logic. 