### PR TITLE
Does a better check on result argument passed to onend callbacks. 

### DIFF
--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -310,8 +310,13 @@ function subscribeToSourceRequestEvents(plugins, sourceRequest, sourceResponse, 
   sourceRequest.on('end', ()=> {
     onend_request_handlers(empty_buffer,
       function(err, result) {
-        err ? logger.error(err) : (result.length && targetRequest.write(result));
-        return err;
+        if(err) {
+          return logger.error(err);
+        }
+
+        if(result && result.length) {
+          targetRequest.write(result)
+        }
       });
   });
 
@@ -355,8 +360,15 @@ function _subscribeToResponseEvents(plugins, sourceRequest, sourceResponse, targ
   targetResponse.on('end', ()=> {
     onend_response_handlers(empty_buffer,
       function(err, result) {
-        err ? logger.error(err) : (result.length && sourceResponse.write(result));
-        cb(err, result);
+        if(err) {
+          logger.error(err);
+        }
+
+        if(result && result.length) {
+          sourceResponse.write(result);
+        }
+
+        return cb(err, result);
       });
   });
 


### PR DESCRIPTION
Previously it would check length, but if null was passed this would cause an error, and append it to the response body.