### PR TITLE
Updates to the request timeout handling logic to actually abort the request.

### DIFF
--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -171,15 +171,21 @@ function getTargetRequest(sourceRequest, sourceResponse, plugins, startTime, cor
   };
 
   
-  if(config.edgemicro.request_timeout) {
-    targetRequestOptions.timeout = config.edgemicro.request_timeout * 1000;
-  }
+  
 
   const targetRequest = httpLibrary.request(targetRequestOptions,
     (targetResponse) => cb(null, targetResponse));
+  
+  if(config.edgemicro.request_timeout) {
+    const timeoutInterval = config.edgemicro.request_timeout * 1000;
+    targetRequest.setTimeout(timeoutInterval, () => {
+      targetRequest._timedOut = true;
+      targetRequest.abort();
+    }); 
+  }
 
   targetRequest.on('error', function(err) {
-
+    
     const logInfo = {
       m: targetRequestOptions.method,
       u: targetRequestOptions.path,
@@ -198,8 +204,14 @@ function getTargetRequest(sourceRequest, sourceResponse, plugins, startTime, cor
           logger.error(e);
           cb(e);
         } else {
-          sourceResponse.statusCode = 502; // Bad Gateway
-          cb(err);
+          if(targetRequest._timedOut) {
+            sourceResponse.statusCode = 504; // Gateway Time-out
+            cb(new Error("Gateway timed out trying to reach target"));
+          } else {
+            sourceResponse.statusCode = 502; // Bad Gateway
+            cb(err);
+          }
+          
         }
       });
   });

--- a/tests/request-timeout-tests.js
+++ b/tests/request-timeout-tests.js
@@ -4,7 +4,7 @@ const _ = require('lodash')
 const assert = require('assert')
 const gatewayService = require('../index')
 const request = require('request')
-const https = require('https')
+const http = require('http')
 const should = require('should')
 const fs = require('fs');
 
@@ -15,11 +15,7 @@ var gateway
 var server
 
 const startGateway = (config, handler, done) => {
-  const opts = {
-    key: fs.readFileSync('./tests/server.key'),
-    cert: fs.readFileSync('./tests/server.crt') 
-  };
-  server = https.createServer(opts, handler);
+  server = http.createServer(handler);
 
   server.listen(port, function() {
     console.log('%s listening at %s', server.name, server.url)
@@ -45,7 +41,7 @@ describe('test configuration handling', () => {
 
   describe('target', () => {
     describe('timeout of request', () => {
-      it('can have the timeout of the request to target tweaked. Causing a 502 bad gateway.', (done) => {
+      it('can have the timeout of the request to target tweaked. Causing a 504 bad gateway.', (done) => {
         
         const baseConfig = {
           edgemicro: {
@@ -60,7 +56,9 @@ describe('test configuration handling', () => {
 
         startGateway(baseConfig, (req, res) => {
           assert.equal('localhost:' + port, req.headers.host)
-          res.end('OK')
+          setTimeout(()=> {
+            res.end('OK')
+          }, 10 * 1000)
         }, () => {
           gateway.start((err) => {
             assert.ok(!err, err)
@@ -70,7 +68,7 @@ describe('test configuration handling', () => {
               url: 'http://localhost:' + gatewayPort + '/v1'
             }, (err, r, body) => {
               assert.ok(!err, err)
-              assert.equal(r.statusCode, 502)
+              assert.equal(r.statusCode, 504)
               done()
             })
           })
@@ -102,7 +100,7 @@ describe('test configuration handling', () => {
               url: 'http://localhost:' + gatewayPort + '/v1'
             }, (err, r, body) => {
               assert.ok(!err, err)
-              assert.equal(r.statusCode, 502)
+              assert.equal(r.statusCode, 200)
               done()
             })
           })


### PR DESCRIPTION
Two things in this pull request.

Setting the `timeout` option on the request doesn't really do what I thought it did. It sets the timeout on the underlying socket to fire a `"timeout"` event that requires interception. In that handler the user is supposed to kill the connection of the underlying socket.

This pull request does a few things:

- Fixes two bad tests that were giving bad gateway errors for the wrong reasons. 
  - One test will look for a 504 indicating the gateway timed out waiting to hear from a target
  - One test will ensure that hearing from the target before the timeout is set doesn't affect the request / response pipeline
- We move from setting the `timeout` option in the options object for the request to using `setTimeout` which will actually fire a callback when the timeout time has been reached.
- Instead of setting a 502 Bad Gateway for timeouts we set a 504 Gateway Time-Out to indicate a different kind of error. This also comes with associated JSON in the response.