### PR TITLE
Fix typo in passphrase option name

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -25,7 +25,7 @@ configService.init = (newConfig) => {
     target.ssl.client.httpsOptions = {
       pfx: target.ssl.client.pfx,
       key: target.ssl.client.key,
-      passpharse: target.ssl.client.passphrase,
+      passphrase: target.ssl.client.passphrase,
       cert: target.ssl.client.cert,
       ca: target.ssl.client.ca,
       ciphers: target.ssl.client.ciphers,


### PR DESCRIPTION
This typo prevents usage of private key passphrase when using 2-way ssl
connection between EMG and target server