### PR TITLE
low-tech fix of key and cert propagation for 2 way-ssl

### DIFF
--- a/lib/config-proxy-middleware.js
+++ b/lib/config-proxy-middleware.js
@@ -44,7 +44,10 @@ module.exports = function () {
           var lastIndex = filtered.length - 1;
           var last = filtered[lastIndex]
           var httpsOptions = last.ssl.client.httpsOptions;
-          opts = _.merge(opts, httpsOptions);
+          var save = opts;
+          opts = httpsOptions;
+          opts.keepAlive = save.keepAlive;
+          opts.maxSockets = save.maxSockets;
         }
         // check for client ssl options
       }


### PR DESCRIPTION
Currently, 2-way ssl connection from EMG to target server is borken because key and cert data are passed as array to `https` instead of being passed as `Buffer`.

key and cert as passed as file path in EMG configuration.

These files are read and saved in httpsOptions as Buffer (that is important).

Some debug log I've added shows a buffer object as (slightly edited for clarity):
```
  key: <Buffer 2d 2d 2d 2d 2d 42 45 47 49 4e  ... >,
```
Unfortunately, the line
```
   opts = _.merge(opts, httpsOptions);
```
 in config-proxy-middleware.js copy the buffer content in an Array. The
 logs then show (slightly edited for clarity):
```
   key:
   [ 45,
     45,
     45,
     45,
     45,
     ... 1604 more items ],
```
The issue comes from lodash library.

The version required by package.json is ~3.9.3. This version is too old. Buffer are properly supported by lodash in version 4 and above.

I've tested that `_.merge` works as expected with lodash 4.15.0

So to fix this issue, you can:
* update lodash version in package.json
* apply this PR which avoids using lodash, should you prefer to keep lodash 3.9.3 dependency

All the best