### PR TITLE
fix 2-way ssl setting to be applied to all targets

### DIFF
--- a/lib/config-proxy-middleware.js
+++ b/lib/config-proxy-middleware.js
@@ -34,7 +34,7 @@ module.exports = function () {
       if (proxy.secure && Array.isArray(config.targets)) {
         var filtered = config.targets.filter(function(target) {
           var hostname = proxy.parsedUrl.hostname;
-          return target.host === hostname
+          return ( ! target.host || target.host === hostname )
             && typeof target.ssl === 'object'
             && typeof target.ssl.client === 'object';
         });


### PR DESCRIPTION
Hello

EMG doc specifies:

> This example provides settings that will be applied to all hosts:
```
targets:
   ssl:
     client:
       key: /Users/jdoe/nodecellar/twowayssl/ssl/client.key
       cert: /Users/jdoe/nodecellar/twowayssl/ssl/ca.crt
       passphrase: admin123
       rejectUnauthorized: true

```

This setting without host does not work: the function passed to `filter()` does not check if host is not specified.

This commit fixes this problem.

All the best
