### PR TITLE
Proxy support

### DIFF
--- a/lib/build-non-tunnel-options.js
+++ b/lib/build-non-tunnel-options.js
@@ -1,0 +1,25 @@
+const url = require('url');
+const qs = require('querystring');
+
+/*
+ * Build options for a proxied request. This means:
+ * Change request options to point at the proxy server
+ * Change path of the request the full URL of where the request should be routed.
+ */ 
+
+module.exports = function(proxy, requestOpts, proxyOpts) {
+  
+  const parsedQuery = url.parse(requestOpts.path);
+  const parsedHttpProxyUrl = url.parse(proxyOpts);
+
+  var newOpts = {
+    method: requestOpts.method,
+    host: parsedHttpProxyUrl.hostname,
+    port: parsedHttpProxyUrl.port,
+    path: proxy.parsedUrl.href,
+    headers: requestOpts.headers,
+    agent: requestOpts.agent
+  }
+
+  return newOpts;
+}

--- a/lib/build-non-tunnel-options.js
+++ b/lib/build-non-tunnel-options.js
@@ -31,10 +31,10 @@ module.exports = (proxy, requestOpts, proxyOpts) => {
 
   var targetPath = url.format(opts);
   const parsedHttpProxyUrl = url.parse(proxyOpts);
-
+  
   var newOpts = {
     method: requestOpts.method,
-    host: parsedHttpProxyUrl.hostname,
+    hostname: parsedHttpProxyUrl.hostname,
     port: parsedHttpProxyUrl.port,
     path: targetPath,
     headers: requestOpts.headers,

--- a/lib/build-non-tunnel-options.js
+++ b/lib/build-non-tunnel-options.js
@@ -7,16 +7,36 @@ const qs = require('querystring');
  * Change path of the request the full URL of where the request should be routed.
  */ 
 
-module.exports = function(proxy, requestOpts, proxyOpts) {
+module.exports = (proxy, requestOpts, proxyOpts) => {
   
   const parsedQuery = url.parse(requestOpts.path);
+
+  var protocol;
+  if(proxy.secure) {
+    protocol = 'https';
+  } else {
+    protocol = 'http';
+  }
+
+  const opts = {
+    pathname: parsedQuery.pathname,
+    hostname: requestOpts.hostname,
+    port: requestOpts.port,
+    protocol: protocol
+  };
+
+  if(parsedQuery.search) {
+    opts.search = parsedQuery.search;
+  }
+
+  var targetPath = url.format(opts);
   const parsedHttpProxyUrl = url.parse(proxyOpts);
 
   var newOpts = {
     method: requestOpts.method,
     host: parsedHttpProxyUrl.hostname,
     port: parsedHttpProxyUrl.port,
-    path: proxy.parsedUrl.href,
+    path: targetPath,
     headers: requestOpts.headers,
     agent: requestOpts.agent
   }

--- a/lib/build-tunnel-agent.js
+++ b/lib/build-tunnel-agent.js
@@ -24,10 +24,7 @@ const createTunnelAgentOptions = (parsedProxyUrl, agentOptions, proxy) => {
   var tunnelOpts = {
     proxy: {
       host: parsedProxyUrl.hostname,
-      port: parsedProxyUrl.port,
-      headers: {
-        host: proxy.parsedUrl.host
-      } 
+      port: parsedProxyUrl.port
     },
     ca: agentOptions.ca,
     cert: agentOptions.cert,

--- a/lib/build-tunnel-agent.js
+++ b/lib/build-tunnel-agent.js
@@ -1,0 +1,68 @@
+const url = require('url');
+const TunnelAgent = require('tunnel-agent');
+
+/*
+ * Build an agent for CONNECT based http tunneling
+ * tunnel-agent takes care of all the socket semantics of passing http requests
+ * over a tunneled TCP connection
+ * 
+ * This is used when a user specifically wants to use a tunnel by specifying the 
+ * tunnel option as true in config, or when the target is TLS enabled.
+ */ 
+
+module.exports = (proxyConfig, agentOptions, proxy, proxyHeaders) => {
+  proxyHeaders = proxyHeaders || {};
+  const parsedProxyUrl = url.parse(proxyConfig); 
+
+  const tunnelOpts = createTunnelAgentOptions(parsedProxyUrl, agentOptions);
+  const tunnelAgentFunction =  getTunnelFunction(proxy.parsedUrl.protocol, parsedProxyUrl.protocol);
+  return tunnelAgentFunction(tunnelOpts);
+}
+
+const createTunnelAgentOptions = (parsedProxyUrl, agentOptions) => {
+
+  var tunnelOpts = {
+    proxy: {
+      host: parsedProxyUrl.hostname,
+      port: parsedProxyUrl.port,
+      headers: {
+        host: agentOptions.host + ':' + agentOptions.port
+      } 
+    },
+    ca: agentOptions.ca,
+    cert: agentOptions.cert,
+    key: agentOptions.key,
+    passphrase: agentOptions.passphrase,
+    pfx: agentOptions.pfx,
+    ciphers: agentOptions.ciphers,
+    rejectUnauthorized: agentOptions.rejectUnauthorized,
+    secureOptions: agentOptions.secureOptions,
+    secureProtocol: agentOptions.secureProtocol
+  };   
+
+  return tunnelOpts;
+}
+
+
+const getTunnelFunction = (targetProtocol, proxyProtocol) => {
+  var functionName = '';
+
+  if(targetProtocol.indexOf('https') > -1) {
+    functionName += 'https';
+  } else {
+    functionName += 'http';
+  }
+
+  functionName += 'Over';
+
+  if(proxyProtocol.indexOf('https') > -1) {
+    functionName += 'Https';
+  } else {
+    functionName += 'Http';
+  }
+
+  return TunnelAgent[functionName];
+}
+
+module.exports.createTunnelAgentOptions = createTunnelAgentOptions;
+module.exports.getTunnelFunction = getTunnelFunction;

--- a/lib/build-tunnel-agent.js
+++ b/lib/build-tunnel-agent.js
@@ -14,19 +14,19 @@ module.exports = (proxyConfig, agentOptions, proxy, proxyHeaders) => {
   proxyHeaders = proxyHeaders || {};
   const parsedProxyUrl = url.parse(proxyConfig); 
 
-  const tunnelOpts = createTunnelAgentOptions(parsedProxyUrl, agentOptions);
+  const tunnelOpts = createTunnelAgentOptions(parsedProxyUrl, agentOptions, proxy);
   const tunnelAgentFunction =  getTunnelFunction(proxy.parsedUrl.protocol, parsedProxyUrl.protocol);
   return tunnelAgentFunction(tunnelOpts);
 }
 
-const createTunnelAgentOptions = (parsedProxyUrl, agentOptions) => {
+const createTunnelAgentOptions = (parsedProxyUrl, agentOptions, proxy) => {
 
   var tunnelOpts = {
     proxy: {
       host: parsedProxyUrl.hostname,
       port: parsedProxyUrl.port,
       headers: {
-        host: agentOptions.host + ':' + agentOptions.port
+        host: proxy.parsedUrl.host
       } 
     },
     ca: agentOptions.ca,

--- a/lib/config-proxy-middleware.js
+++ b/lib/config-proxy-middleware.js
@@ -21,22 +21,37 @@ module.exports = function () {
   //TODO: Respect HTTP_PROXY and HTTPS_PROXY
   const httpProxyConfig = config.edgemicro.proxy;
   const httpProxyTunnelConfig = config.edgemicro.proxy_tunnel;
+
   if(config && config.proxies) {
     config.proxies.forEach(function (proxy) {
-      
+      var parsedHttpProxyConfig = url.parse(httpProxyConfig);
+      var secureProxy = parsedHttpProxyConfig.protocol === 'https:';
+     
       proxy.parsedUrl = url.parse(proxy.url);
       const secure = proxy.parsedUrl.protocol === 'https:';
       proxy.basePathLength = proxy.base_path.length;
       proxy.secure = secure;
-      const agentLib = secure ? https : http;
+      proxy.secureHttpProxy = secureProxy;
+      var agentLib = http;
+
+      if(secure || secureProxy) {
+        agentLib = https;
+      }
       var opts = {
         maxSockets: limit(proxy.max_connections),
         keepAlive: true
       }
 
-      if (proxy.secure && Array.isArray(config.targets)) {
+      if ((proxy.secure || proxy.secureHttpProxy) && Array.isArray(config.targets)) {
+        
         var filtered = config.targets.filter(function(target) {
           var hostname = proxy.parsedUrl.hostname;
+
+          //If our proxy configuration is https let's check for any configuration
+          //for enabling TLS
+          if (proxy.secureHttpProxy) {
+            hostname = parsedHttpProxyConfig.hostname;
+          } 
           return target.host === hostname
             && typeof target.ssl === 'object'
             && typeof target.ssl.client === 'object';
@@ -47,7 +62,10 @@ module.exports = function () {
           var lastIndex = filtered.length - 1;
           var last = filtered[lastIndex]
           var httpsOptions = last.ssl.client.httpsOptions;
-          opts = _.merge(opts, httpsOptions);
+          var save = opts;
+          opts = httpsOptions;
+          opts.keepAlive = save.keepAlive;
+          opts.maxSockets = save.maxSockets;
         }
         // check for client ssl options
       }

--- a/lib/config-proxy-middleware.js
+++ b/lib/config-proxy-middleware.js
@@ -24,9 +24,11 @@ module.exports = function () {
 
   if(config && config.proxies) {
     config.proxies.forEach(function (proxy) {
-      var parsedHttpProxyConfig = url.parse(httpProxyConfig);
-      var secureProxy = parsedHttpProxyConfig.protocol === 'https:';
-     
+      if(httpProxyConfig) {
+        var parsedHttpProxyConfig = url.parse(httpProxyConfig);
+        var secureProxy = parsedHttpProxyConfig.protocol === 'https:';
+      }
+      
       proxy.parsedUrl = url.parse(proxy.url);
       const secure = proxy.parsedUrl.protocol === 'https:';
       proxy.basePathLength = proxy.base_path.length;

--- a/lib/config-proxy-middleware.js
+++ b/lib/config-proxy-middleware.js
@@ -20,7 +20,7 @@ module.exports = function () {
   const config = configService.get();
   //TODO: Respect HTTP_PROXY and HTTPS_PROXY
   const httpProxyConfig = config.edgemicro.proxy;
-  const httpProxyTunnelConfig = config.edgemicro.tunnel;
+  const httpProxyTunnelConfig = config.edgemicro.proxy_tunnel;
   if(config && config.proxies) {
     config.proxies.forEach(function (proxy) {
       
@@ -52,9 +52,10 @@ module.exports = function () {
         // check for client ssl options
       }
 
-      if(httpProxyConfig && (httpProxyConfig.tunnel || secure)) {
-        // proxy.agent = buildTunnelAgent(httpProxyConfig, opts, proxy)
-        // proxy.tunnelEnabled = true;
+      if(httpProxyConfig && (httpProxyTunnelConfig || secure)) {
+        const tunnelAgent = buildTunnelAgent(httpProxyConfig, opts, proxy);
+        proxy.agent = tunnelAgent;
+        proxy.tunnelEnabled = true;
       } else {
         proxy.agent = new agentLib.Agent(opts);
         proxy.tunnelEnabled = false;

--- a/lib/config-proxy-middleware.js
+++ b/lib/config-proxy-middleware.js
@@ -8,7 +8,7 @@ const double_slash_regex = /\/\/+/g;
 const http = require('http');
 const https = require('https');
 const _ = require('lodash');
-
+const buildTunnelAgent = require('./build-tunnel-agent')
 
 /**
  * adds proxy to request
@@ -18,9 +18,12 @@ const _ = require('lodash');
 module.exports = function () {
 
   const config = configService.get();
-
+  //TODO: Respect HTTP_PROXY and HTTPS_PROXY
+  const httpProxyConfig = config.edgemicro.proxy;
+  const httpProxyTunnelConfig = config.edgemicro.tunnel;
   if(config && config.proxies) {
     config.proxies.forEach(function (proxy) {
+      
       proxy.parsedUrl = url.parse(proxy.url);
       const secure = proxy.parsedUrl.protocol === 'https:';
       proxy.basePathLength = proxy.base_path.length;
@@ -49,7 +52,13 @@ module.exports = function () {
         // check for client ssl options
       }
 
-      proxy.agent = new agentLib.Agent(opts);
+      if(httpProxyConfig && (httpProxyConfig.tunnel || secure)) {
+        // proxy.agent = buildTunnelAgent(httpProxyConfig, opts, proxy)
+        // proxy.tunnelEnabled = true;
+      } else {
+        proxy.agent = new agentLib.Agent(opts);
+        proxy.tunnelEnabled = false;
+      }
     });
   }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -34,7 +34,7 @@ configService.init = (newConfig) => {
     target.ssl.client.httpsOptions = {
       pfx: target.ssl.client.pfx,
       key: target.ssl.client.key,
-      passpharse: target.ssl.client.passphrase,
+      passphrase: target.ssl.client.passphrase,
       cert: target.ssl.client.cert,
       ca: target.ssl.client.ca,
       ciphers: target.ssl.client.ciphers,
@@ -50,5 +50,6 @@ configService.init = (newConfig) => {
         target.ssl.client.httpsOptions[opt] = fs.readFileSync(filename);
       }
     });
+
   });
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -14,6 +14,15 @@ configService.init = (newConfig) => {
   config.edgemicro = config.edgemicro || { plugins: {} };
   config.targets = config.targets || [];
 
+  //Iterate through each proxy variable. If it's present in the environment let's place 
+  //it in the edgemicro configuration.
+  var httpProxyEnvVariables = ['HTTP_PROXY', 'HTTPS_PROXY', 'http_proxy', 'https_proxy'];
+  httpProxyEnvVariables.forEach((v)=> {
+    if(process.env[v]) {
+      config.edgemicro.proxy = process.env[v];
+    }
+  });
+
   config.targets.forEach(function(target) {
     if (typeof target.ssl !== 'object'
         || typeof target.ssl.client !== 'object') {

--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -172,14 +172,12 @@ function getTargetRequest(sourceRequest, sourceResponse, plugins, startTime, cor
   };
 
   const httpProxyConfig = config.edgemicro.proxy;
-  const httpProxyTunnelConfig = config.edgemicro.tunnel;
+  const httpProxyTunnelConfig = config.edgemicro.proxy_tunnel;
 
   //If we have a proxy configuration, but we aren't tunneling. 
   //Rewrite target request options to account for proxy configuration
   if(httpProxyConfig && !httpProxyTunnelConfig) {
-    console.log('Building new options for request');
     targetRequestOptions = buildNonTunnelOptions(proxy,targetRequestOptions, httpProxyConfig);
-    console.log(targetRequestOptions);
   }
   
   if(config.edgemicro.request_timeout) {

--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -13,6 +13,7 @@ const assert = require('assert');
 const stats = require('./stats')
 const OnDataTransform = require('./ondata-transform');
 const configService = require('./config');
+const buildNonTunnelOptions = require('./build-non-tunnel-options')
 const empty_buffer = new Buffer(0);
 
 /**
@@ -161,7 +162,7 @@ function getTargetRequest(sourceRequest, sourceResponse, plugins, startTime, cor
   const httpLibrary = proxy.secure ? https : http;
   assert(httpLibrary.request, 'must have request method');
 
-  const targetRequestOptions = {
+  var targetRequestOptions = {
     hostname: sourceRequest.targetHostname,
     port: proxy.parsedUrl.port,
     path: sourceRequest.targetPath,
@@ -170,6 +171,16 @@ function getTargetRequest(sourceRequest, sourceResponse, plugins, startTime, cor
     agent: proxy.agent
   };
 
+  const httpProxyConfig = config.edgemicro.proxy;
+  const httpProxyTunnelConfig = config.edgemicro.tunnel;
+
+  //If we have a proxy configuration, but we aren't tunneling. 
+  //Rewrite target request options to account for proxy configuration
+  if(httpProxyConfig && !httpProxyTunnelConfig) {
+    console.log('Building new options for request');
+    targetRequestOptions = buildNonTunnelOptions(proxy,targetRequestOptions, httpProxyConfig);
+    console.log(targetRequestOptions);
+  }
   
   if(config.edgemicro.request_timeout) {
     targetRequestOptions.timeout = config.edgemicro.request_timeout * 1000;

--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -159,7 +159,12 @@ function getTargetRequest(sourceRequest, sourceResponse, plugins, startTime, cor
     }
   }
 
-  const httpLibrary = proxy.secure ? https : http;
+  var httpLibrary = http;
+
+  if (proxy.secure || proxy.secureHttpProxy) {
+    httpLibrary = https;
+  }
+
   assert(httpLibrary.request, 'must have request method');
 
   var targetRequestOptions = {
@@ -171,19 +176,23 @@ function getTargetRequest(sourceRequest, sourceResponse, plugins, startTime, cor
     agent: proxy.agent
   };
 
+  
+
   const httpProxyConfig = config.edgemicro.proxy;
   const httpProxyTunnelConfig = config.edgemicro.proxy_tunnel;
 
   //If we have a proxy configuration, but we aren't tunneling. 
   //Rewrite target request options to account for proxy configuration
   if(httpProxyConfig && !httpProxyTunnelConfig) {
-    targetRequestOptions = buildNonTunnelOptions(proxy,targetRequestOptions, httpProxyConfig);
+    targetRequestOptions = buildNonTunnelOptions(proxy, targetRequestOptions, httpProxyConfig);
   }
   
+
   if(config.edgemicro.request_timeout) {
     targetRequestOptions.timeout = config.edgemicro.request_timeout * 1000;
   }
 
+  
   const targetRequest = httpLibrary.request(targetRequestOptions,
     (targetResponse) => cb(null, targetResponse));
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "debug": "~2.2.0",
     "lodash": "~3.9.3",
     "request": "~2.74.0",
+    "tunnel-agent": "^0.4.3",
     "uuid": "~2.0.1",
     "winston": "~2.2.0",
     "winston-daily-rotate-file": "~1.0.1"

--- a/tests/proxy-options-tests.js
+++ b/tests/proxy-options-tests.js
@@ -1,0 +1,101 @@
+var BuildNonTunnelOptions = require('../lib/build-non-tunnel-options');
+var assert = require('assert');
+var url = require('url');
+
+describe('Building non tunnel options', ()=> {
+    it('Will properly build non tunnel options for the given inputs', ()=> {
+        var proxy = {
+            secure: true
+        }
+
+        var proxyConfig = {
+            proxy: 'http://localhost:8080'
+        }
+
+        var requestOptions = {
+            path: '/',
+            hostname: 'localhost',
+            port: 9090,
+            agent: false, 
+            method: 'GET',
+            headers: {
+                'foo': 'bar'
+            }
+        }
+
+        var opts = BuildNonTunnelOptions(proxy, requestOptions, proxyConfig.proxy);
+        
+        var path = 'https://localhost:9090/';
+
+        assert.equal(opts.path, path);
+        assert.equal(opts.method, 'GET');
+        assert.equal(opts.agent, false);
+        assert.equal(opts.hostname, 'localhost');
+        assert.equal(opts.port, '8080');
+        assert.equal(opts.headers.foo, 'bar');
+    });
+
+    it('Will properly build non tunnel options for the path supplied', ()=> {
+        var proxy = {
+            secure: true
+        }
+
+        var proxyConfig = {
+            proxy: 'http://localhost:8080'
+        }
+
+        var requestOptions = {
+            path: '/?foo=bar',
+            hostname: 'localhost',
+            port: 9090,
+            agent: false, 
+            method: 'GET',
+            headers: {
+                'foo': 'bar'
+            }
+        }
+
+        var opts = BuildNonTunnelOptions(proxy, requestOptions, proxyConfig.proxy);
+        
+        var path = 'https://localhost:9090/?foo=bar';
+
+        assert.equal(opts.path, path);
+        assert.equal(opts.method, 'GET');
+        assert.equal(opts.agent, false);
+        assert.equal(opts.hostname, 'localhost');
+        assert.equal(opts.port, '8080');
+        assert.equal(opts.headers.foo, 'bar');
+    });
+
+    it('Will properly build non tunnel options for the non-secure proxy supplied', ()=> {
+        var proxy = {
+            secure: false
+        }
+
+        var proxyConfig = {
+            proxy: 'http://localhost:8080'
+        }
+
+        var requestOptions = {
+            path: '/?foo=bar',
+            hostname: 'localhost',
+            port: 9090,
+            agent: false, 
+            method: 'GET',
+            headers: {
+                'foo': 'bar'
+            }
+        }
+
+        var opts = BuildNonTunnelOptions(proxy, requestOptions, proxyConfig.proxy);
+        
+        var path = 'http://localhost:9090/?foo=bar';
+
+        assert.equal(opts.path, path);
+        assert.equal(opts.method, 'GET');
+        assert.equal(opts.agent, false);
+        assert.equal(opts.hostname, 'localhost');
+        assert.equal(opts.port, '8080');
+        assert.equal(opts.headers.foo, 'bar');
+    });
+});

--- a/tests/proxy-tests-tls.js
+++ b/tests/proxy-tests-tls.js
@@ -27,6 +27,8 @@ const startGateway = (config, handler, done) => {
     cert: fs.readFileSync('./tests/server.crt') 
   };
 
+  //This is a mock proxy server. 
+  //Meant to replicate a squid proxy in basic functionality for testing purposes.
   proxy = https.createServer(opts, (req, res) => {
     var r = request({
       url: req.url,

--- a/tests/proxy-tests-tls.js
+++ b/tests/proxy-tests-tls.js
@@ -1,0 +1,255 @@
+'use strict'
+
+const _ = require('lodash')
+const assert = require('assert')
+const gatewayService = require('../index')
+const request = require('request')
+const http = require('http')
+const https = require('https')
+const should = require('should')
+const fs = require('fs');
+const net = require('net');
+const tls = require('tls');
+const url = require('url');
+const util = require('util');
+
+const gatewayPort = 8800
+const proxyPort = 4490;
+const port = 3300
+
+var gateway
+var proxy
+var server
+
+const startGateway = (config, handler, done) => {
+  const opts = {
+    key: fs.readFileSync('./tests/server.key'),
+    cert: fs.readFileSync('./tests/server.crt') 
+  };
+
+  proxy = https.createServer(opts, (req, res) => {
+    var r = request({
+      url: req.url,
+      method: req.method,
+      headers: req.headers
+    });
+
+    req.pipe(r).pipe(res);
+  }).on('connect', (req, cltSocket, head) => {
+    
+    var proto, netLib;
+    if(req.url.indexOf('443') > -1) {
+      proto = 'https';
+      netLib = tls;
+    } else {  
+      proto = 'http';
+      netLib = net;
+    }
+
+    const connectionCb = () => {
+      cltSocket.write([
+        'HTTP/1.1 200 Connection Established\r\n', 
+        'Proxy-agent: Node.js-Proxy\r\n',
+        '\r\n'
+        ].join(''));
+
+      targetConnection.write(head);
+      targetConnection.pipe(cltSocket);
+      cltSocket.pipe(targetConnection);
+    } 
+
+    var targetUrl = url.parse(util.format('%s://%s', proto, req.url));
+
+    var targetConnection; 
+    if(proto == 'http') {
+      targetConnection = netLib.connect(targetUrl.port, targetUrl.hostname, connectionCb)
+    } else {
+      if(targetUrl.hostname == 'localhost') {
+        try {
+          targetConnection = netLib.connect(opts, targetUrl.port, targetUrl.hostname, connectionCb);
+        } catch(e) {
+          console.log('Error connecting.');
+          console.log(e);
+        }
+      } else {
+        try {
+          targetConnection = netLib.connect(targetUrl.port, targetUrl.hostname, connectionCb);
+        } catch(e) {
+          console.log('Error connecting.');
+          console.log(e);
+        }
+      }
+    }
+  });
+
+  server = http.createServer(handler);
+
+  server.listen(port, function() {
+    console.log('API Server %s listening at %s', server.name, server.url)
+
+    proxy.listen(proxyPort, function(){
+      console.log('Proxy Server %s listening at %s', proxy.name, proxy.url)
+      gateway = gatewayService(config)
+
+      done()
+    }); 
+    
+  })
+}
+
+describe('test configuration handling', () => {
+  afterEach((done) => {
+    if (gateway) {
+      gateway.stop(() => {})
+    }
+
+    if (server) {
+      server.close()
+      proxy.close()
+    }
+
+    done()
+  })
+
+  describe('proxy', () => {
+    describe('non tunneling https proxy', () => {
+      it('route traffic through an https proxy', (done) => {
+        
+        const baseConfig = {
+          edgemicro: {
+            port: gatewayPort,
+            logging: { level: 'info', dir: './tests/log' },
+            proxy: 'https://localhost:' + proxyPort
+          },
+          proxies: [
+            { base_path: '/v1', secure: false, url: 'http://localhost:' + port }
+          ], 
+          targets: [
+            {
+              host: 'localhost',
+              ssl: {
+                client: {
+                  cert: './tests/server.crt',
+                  key: './tests/server.key',
+                  rejectUnauthorized: false
+                }
+              }
+            }  
+          ]
+        }
+
+        startGateway(baseConfig, (req, res) => {
+          assert.equal('localhost:' + proxyPort, req.headers.host)
+          res.end('OK')
+        }, () => {
+          gateway.start((err) => {
+            assert.ok(!err, err)
+
+            request({
+              method: 'GET',
+              url: 'http://localhost:' + gatewayPort + '/v1'
+            }, (err, r, body) => {
+              assert.ok(!err, err)
+              assert.equal(r.statusCode, 200)
+              done()
+            })
+          })
+        })
+      })
+
+      it('route traffic through an http proxy with forced non-tunneling', (done) => {
+        
+        const baseConfig = {
+          edgemicro: {
+            port: gatewayPort,
+            logging: { level: 'info', dir: './tests/log' },
+            proxy: 'https://localhost:' + proxyPort,
+            proxy_tunnel: false
+          },
+          proxies: [
+            { base_path: '/v1', secure: false, url: 'http://localhost:' + port }
+          ], 
+          targets: [
+            {
+              host: 'localhost',
+              ssl: {
+                client: {
+                  cert: './tests/server.crt',
+                  key: './tests/server.key',
+                  rejectUnauthorized: false
+                }
+              }
+            }  
+          ]
+        }
+
+        startGateway(baseConfig, (req, res) => {
+          assert.equal('localhost:' + proxyPort, req.headers.host)
+          res.end('OK')
+        }, () => {
+          gateway.start((err) => {
+            assert.ok(!err, err)
+
+            request({
+              method: 'GET',
+              url: 'http://localhost:' + gatewayPort + '/v1'
+            }, (err, r, body) => {
+              assert.ok(!err, err)
+              assert.equal(r.statusCode, 200)
+              done()
+            })
+          })
+        })
+      })
+
+      it('route traffic through an http proxy with forced tunneling', (done) => {
+        //We need to do this to have the tunnel-agent reject self signed certs
+        //These are tests so don't do this in real life
+        //This is ONLY for the purpose of testing.
+        process.env.NODE_TLS_REJECT_UNAUTHORIZED=0;
+        const baseConfig = {
+          edgemicro: {
+            port: gatewayPort,
+            logging: { level: 'info', dir: './tests/log' },
+            proxy: 'https://localhost:' + proxyPort,
+            proxy_tunnel: true
+          },
+          proxies: [
+            { base_path: '/v1', secure: false, url: 'http://localhost:' + port }
+          ], 
+          targets: [
+            {
+              host: 'localhost',
+              ssl: {
+                client: {
+                  cert: './tests/server.crt',
+                  key: './tests/server.key',
+                  rejectUnauthorized: false
+                }
+              }
+            }  
+          ]
+        }
+
+        startGateway(baseConfig, (req, res) => {
+          assert.equal('localhost:' + port, req.headers.host)
+          res.end('OK')
+        }, () => {
+          gateway.start((err) => {
+            assert.ok(!err, err)
+
+            request({
+              method: 'GET',
+              url: 'http://localhost:' + gatewayPort + '/v1'
+            }, (err, r, body) => {
+              assert.ok(!err, err)
+              assert.equal(r.statusCode, 200)
+              done()
+            })
+          })
+        })
+      })
+
+    })
+  })
+})

--- a/tests/proxy-tests.js
+++ b/tests/proxy-tests.js
@@ -1,0 +1,211 @@
+'use strict'
+
+const _ = require('lodash')
+const assert = require('assert')
+const gatewayService = require('../index')
+const request = require('request')
+const http = require('http')
+const should = require('should')
+const fs = require('fs');
+const net = require('net');
+const tls = require('tls');
+const url = require('url');
+const util = require('util');
+
+const gatewayPort = 8800
+const proxyPort = 4490;
+const port = 3300
+
+var gateway
+var proxy
+var server
+
+const startGateway = (config, handler, done) => {
+  proxy = http.createServer((req, res) => {
+    var r = request({
+      url: req.url,
+      method: req.method,
+      headers: req.headers
+    });
+
+    req.pipe(r).pipe(res);
+  }).on('connect', (req, cltSocket, head) => {
+    
+    var proto, netLib;
+    if(req.url.indexOf('443') > -1) {
+      proto = 'https';
+      netLib = tls;
+    } else {  
+      proto = 'http';
+      netLib = net;
+    }
+
+    const connectionCb = () => {
+      cltSocket.write([
+        'HTTP/1.1 200 Connection Established\r\n', 
+        'Proxy-agent: Node.js-Proxy\r\n',
+        '\r\n'
+        ].join(''));
+
+      targetConnection.write(head);
+      targetConnection.pipe(cltSocket);
+      cltSocket.pipe(targetConnection);
+    } 
+
+    var targetUrl = url.parse(util.format('%s://%s', proto, req.url));
+
+    var targetConnection; 
+    if(proto == 'http') {
+      targetConnection = netLib.connect(targetUrl.port, targetUrl.hostname, connectionCb)
+    } else {
+      if(targetUrl.hostname == 'localhost') {
+        try {
+          targetConnection = netLib.connect(opts, targetUrl.port, targetUrl.hostname, connectionCb);
+        } catch(e) {
+          console.log('Error connecting.');
+          console.log(e);
+        }
+      } else {
+        try {
+          targetConnection = netLib.connect(targetUrl.port, targetUrl.hostname, connectionCb);
+        } catch(e) {
+          console.log('Error connecting.');
+          console.log(e);
+        }
+      }
+    }
+  });
+
+  server = http.createServer(handler);
+
+  server.listen(port, function() {
+    console.log('API Server %s listening at %s', server.name, server.url)
+
+    proxy.listen(proxyPort, function(){
+      console.log('Proxy Server %s listening at %s', proxy.name, proxy.url)
+      gateway = gatewayService(config)
+
+      done()
+    }); 
+    
+  })
+}
+
+describe('test configuration handling', () => {
+  afterEach((done) => {
+    if (gateway) {
+      gateway.stop(() => {})
+    }
+
+    if (server) {
+      server.close()
+      proxy.close()
+    }
+
+    done()
+  })
+
+  describe('proxy', () => {
+    describe('non tunneling http proxy', () => {
+      it('route traffic through an http proxy', (done) => {
+        
+        const baseConfig = {
+          edgemicro: {
+            port: gatewayPort,
+            logging: { level: 'info', dir: './tests/log' },
+            proxy: 'http://localhost:' + proxyPort
+          },
+          proxies: [
+            { base_path: '/v1', secure: false, url: 'http://localhost:' + port }
+          ]
+        }
+
+        startGateway(baseConfig, (req, res) => {
+          assert.equal('localhost:' + proxyPort, req.headers.host)
+          res.end('OK')
+        }, () => {
+          gateway.start((err) => {
+            assert.ok(!err, err)
+
+            request({
+              method: 'GET',
+              url: 'http://localhost:' + gatewayPort + '/v1'
+            }, (err, r, body) => {
+              assert.ok(!err, err)
+              assert.equal(r.statusCode, 200)
+              done()
+            })
+          })
+        })
+      })
+
+      it('route traffic through an http proxy with forced non-tunneling', (done) => {
+        
+        const baseConfig = {
+          edgemicro: {
+            port: gatewayPort,
+            logging: { level: 'info', dir: './tests/log' },
+            proxy: 'http://localhost:' + proxyPort,
+            proxy_tunnel: false
+          },
+          proxies: [
+            { base_path: '/v1', secure: false, url: 'http://localhost:' + port }
+          ]
+        }
+
+        startGateway(baseConfig, (req, res) => {
+          assert.equal('localhost:' + proxyPort, req.headers.host)
+          res.end('OK')
+        }, () => {
+          gateway.start((err) => {
+            assert.ok(!err, err)
+
+            request({
+              method: 'GET',
+              url: 'http://localhost:' + gatewayPort + '/v1'
+            }, (err, r, body) => {
+              assert.ok(!err, err)
+              assert.equal(r.statusCode, 200)
+              done()
+            })
+          })
+        })
+      })
+
+      it('route traffic through an http proxy with forced tunneling', (done) => {
+        
+        const baseConfig = {
+          edgemicro: {
+            port: gatewayPort,
+            logging: { level: 'info', dir: './tests/log' },
+            proxy: 'http://localhost:' + proxyPort,
+            proxy_tunnel: true
+          },
+          proxies: [
+            { base_path: '/v1', secure: false, url: 'http://localhost:' + port }
+          ]
+        }
+
+        startGateway(baseConfig, (req, res) => {
+          assert.equal('localhost:' + port, req.headers.host)
+          res.end('OK')
+        }, () => {
+          gateway.start((err) => {
+            assert.ok(!err, err)
+
+            request({
+              method: 'GET',
+              url: 'http://localhost:' + gatewayPort + '/v1'
+            }, (err, r, body) => {
+              assert.ok(!err, err)
+              assert.equal(r.statusCode, 200)
+              done()
+            })
+          })
+        })
+      })
+
+
+    })
+  })
+})

--- a/tests/proxy-tests.js
+++ b/tests/proxy-tests.js
@@ -21,6 +21,9 @@ var proxy
 var server
 
 const startGateway = (config, handler, done) => {
+
+  //This is a mock proxy server. 
+  //Meant to replicate a squid proxy in basic functionality for testing purposes.
   proxy = http.createServer((req, res) => {
     var r = request({
       url: req.url,

--- a/tests/proxy-tests.js
+++ b/tests/proxy-tests.js
@@ -205,7 +205,6 @@ describe('test configuration handling', () => {
         })
       })
 
-
     })
   })
 })


### PR DESCRIPTION
WIP

This is to implement proxying support for the following configuration options in microgateway.

```yaml
edge_config:
  proxy: http://10.224.16.85:3128
  proxy_tunnel: false
```

Also will build in support for the `HTTP_PROXY`, `HTTPS_PROXY`, `http_proxy`, and `https_proxy` environment variables.

This will allow a user to set these specific variables, or configuration to have edgemicro route it's http traffic through a proxy server. This is currently half supported in retrieving configuration, but in the actual API message processing it isn't supported.

We're using a similar approach to the `request` module, and a library they produced for http tunneling called `tunnel-agent`. This will allow us to use connect tunneling, or putting a full URL in the path of a request.

Task list and marked if completed.

- [X] CONNECT tunneling implementation with `tunnel-agent`
- [X] http proxy implementation with rewriting request options to place a full URL in the path
- [x] Support the `HTTP_PROXY`, `HTTPS_PROXY`, `http_proxy`, and `https_proxy` env variables.
- [x] CONNECT tunneling tests
- [x] http proxy tests
- [X] add `tunnel-agent` to the package.json