### PR TITLE
We need to respect the no_proxy environment variable.

### DIFF
--- a/lib/config-proxy-middleware.js
+++ b/lib/config-proxy-middleware.js
@@ -9,6 +9,7 @@ const http = require('http');
 const https = require('https');
 const _ = require('lodash');
 const buildTunnelAgent = require('./build-tunnel-agent')
+const checkNoProxy = require('./no-proxy-parser')
 
 /**
  * adds proxy to request
@@ -73,7 +74,9 @@ module.exports = function () {
         // check for client ssl options
       }
 
-      if(httpProxyConfig && (httpProxyTunnelConfig || secure)) {
+      var noProxy = process.env.NO_PROXY || process.env.no_proxy;
+      const shouldntUseProxy = checkNoProxy(proxy.url, noProxy); 
+      if(httpProxyConfig && (httpProxyTunnelConfig || secure) && !shouldntUseProxy) {
         const tunnelAgent = buildTunnelAgent(httpProxyConfig, opts, proxy);
         proxy.agent = tunnelAgent;
         proxy.tunnelEnabled = true;

--- a/lib/config.js
+++ b/lib/config.js
@@ -16,9 +16,11 @@ configService.init = (newConfig) => {
 
   //Iterate through each proxy variable. If it's present in the environment let's place 
   //it in the edgemicro configuration.
+  //If NO_PROXY is set then do not respect those variables
   var httpProxyEnvVariables = ['HTTP_PROXY', 'HTTPS_PROXY', 'http_proxy', 'https_proxy'];
+  var noProxy = process.env.NO_PROXY || process.env.no_proxy; 
   httpProxyEnvVariables.forEach((v)=> {
-    if(process.env[v]) {
+    if(process.env[v] && !noProxy) {
       config.edgemicro.proxy = process.env[v];
     }
   });

--- a/lib/no-proxy-parser.js
+++ b/lib/no-proxy-parser.js
@@ -1,0 +1,46 @@
+const url = require('url')
+
+function canonicalizeHostname(h) {
+    return h.replace(/^\.*/, '.').toLowerCase();
+}
+
+function parseNoProxy(noProxyVar) {
+  var hosts = noProxyVar.split(',');
+
+  var formattedHosts = hosts.map((h) => {
+    var hostParts = h.split(':');
+    return {
+      host: canonicalizeHostname(hostParts[0]),
+      port: hostParts[1]
+    }
+  });
+  return formattedHosts; 
+}
+
+function matchHostAgainstNoProxy(host, noProxyVar) {
+  var parsedHosts = parseNoProxy(noProxyVar);
+  var parsedHostToMatch = url.parse(host);
+  var canonicalHost = canonicalizeHostname(parsedHostToMatch.hostname);
+
+  if(!parsedHostToMatch.port) {
+    parsedHostToMatch.port = parsedHostToMatch.protocol == 'https:' ? '443' : '80';
+  }
+
+  return parsedHosts.some((e) => {
+    var matchIndex = e.host.indexOf(canonicalHost);
+    const match = matchIndex > -1
+
+    var perfectHostMatch = match && (matchIndex == e.host.length - canonicalHost.length);
+
+    if(e.port) {
+      return parsedHostToMatch.port == e.port && perfectHostMatch; 
+    } else {
+      return perfectHostMatch;
+    }
+  });
+}
+
+module.exports = matchHostAgainstNoProxy;
+
+
+

--- a/lib/no-proxy-parser.js
+++ b/lib/no-proxy-parser.js
@@ -18,6 +18,9 @@ function parseNoProxy(noProxyVar) {
 }
 
 function matchHostAgainstNoProxy(host, noProxyVar) {
+  if(!host || !noProxyVar) {
+    return false;
+  }
   var parsedHosts = parseNoProxy(noProxyVar);
   var parsedHostToMatch = url.parse(host);
   var canonicalHost = canonicalizeHostname(parsedHostToMatch.hostname);

--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -14,6 +14,7 @@ const stats = require('./stats')
 const OnDataTransform = require('./ondata-transform');
 const configService = require('./config');
 const buildNonTunnelOptions = require('./build-non-tunnel-options')
+const checkNoProxy = require('./no-proxy-parser')
 const empty_buffer = new Buffer(0);
 
 /**
@@ -181,7 +182,10 @@ function getTargetRequest(sourceRequest, sourceResponse, plugins, startTime, cor
 
   //If we have a proxy configuration, but we aren't tunneling. 
   //Rewrite target request options to account for proxy configuration
-  if(httpProxyConfig && !httpProxyTunnelConfig) {
+
+  var noProxy = process.env.NO_PROXY || process.env.no_proxy;
+  const shouldntUseProxy = checkNoProxy(proxy.url, noProxy); 
+  if(httpProxyConfig && !httpProxyTunnelConfig && !shouldntUseProxy) {
     targetRequestOptions = buildNonTunnelOptions(proxy, targetRequestOptions, httpProxyConfig);
   }
   

--- a/tests/no-proxy-parser-tests.js
+++ b/tests/no-proxy-parser-tests.js
@@ -81,4 +81,25 @@ describe('no proxy variable parsing and matching', () => {
     const matched = NoProxyParseAndMatch('http://bar.baz/', 'localhost,foo.bar,bar.baz');
     assert.equal(matched, true);
   });
+
+
+  it('will parse and match a host with port that is second in list when no proxy is comma delimited list', ()=> {
+    const matched = NoProxyParseAndMatch('http://foo.bar:8080/', 'localhost,foo.bar:8080,bar.baz');
+    assert.equal(matched, true);
+  });
+
+  it('will parse and match a host with port that is last in list when no proxy is comma delimited list', ()=> {
+    const matched = NoProxyParseAndMatch('http://bar.baz:8080/', 'localhost,foo.bar,bar.baz:8080');
+    assert.equal(matched, true);
+  });
+
+  it('will not partially match hosts', () => {
+    const matched = NoProxyParseAndMatch('http://ar.baz:8080/', 'localhost,foo.bar,bar.baz:8080');
+    assert.equal(matched, false);
+  });
+
+  it('will not partially match hosts with only one in no_proxy list', () => {
+    const matched = NoProxyParseAndMatch('http://foo/', 'foo.bar');
+    assert.equal(matched, false);
+  });
 });

--- a/tests/no-proxy-parser-tests.js
+++ b/tests/no-proxy-parser-tests.js
@@ -66,4 +66,19 @@ describe('no proxy variable parsing and matching', () => {
     const matched = NoProxyParseAndMatch('', 'localhost');
     assert.equal(matched, false);
   });
+  
+  it('will parse and match a host when no proxy is comma delimited list', ()=> {
+    const matched = NoProxyParseAndMatch('http://localhost/', 'localhost,foo.bar,bar.baz');
+    assert.equal(matched, true);
+  });
+
+  it('will parse and match a host that is second in list when no proxy is comma delimited list', ()=> {
+    const matched = NoProxyParseAndMatch('http://foo.bar/', 'localhost,foo.bar,bar.baz');
+    assert.equal(matched, true);
+  });
+
+  it('will parse and match a host that is last in list when no proxy is comma delimited list', ()=> {
+    const matched = NoProxyParseAndMatch('http://bar.baz/', 'localhost,foo.bar,bar.baz');
+    assert.equal(matched, true);
+  });
 });

--- a/tests/no-proxy-parser-tests.js
+++ b/tests/no-proxy-parser-tests.js
@@ -1,0 +1,39 @@
+const assert = require('assert');
+const NoProxyParseAndMatch = require('../lib/no-proxy-parser');
+
+describe('no proxy variable parsing and matching', () => {
+  it('will parse and match a host in the list', ()=> {
+    const matched = NoProxyParseAndMatch('http://localhost/', 'localhost');
+    assert.equal(matched, true);
+  });
+
+  it('will parse and not match a host in the list', ()=> {
+    const matched = NoProxyParseAndMatch('http://foo.bar/', 'localhost');
+    assert.equal(matched, false);
+  });
+
+  it('will parse and match a host with port in the list', ()=> {
+    const matched = NoProxyParseAndMatch('http://localhost:8080/', 'localhost:8080');
+    assert.equal(matched, true);
+  });
+
+  it('will parse and not match a host with port in the list', ()=> {
+    const matched = NoProxyParseAndMatch('http://localhost:8081/', 'localhost:8080');
+    assert.equal(matched, false);
+  });
+
+  it('will parse and match a host with default TLS port in the list', ()=> {
+    const matched = NoProxyParseAndMatch('https://localhost/', 'localhost:443');
+    assert.equal(matched, true);
+  });
+
+  it('will parse and match a host with default HTTP port in the list', ()=> {
+    const matched = NoProxyParseAndMatch('http://localhost/', 'localhost:80');
+    assert.equal(matched, true);
+  });
+
+  it('will parse and match a host regardless of port information', ()=> {
+    const matched = NoProxyParseAndMatch('http://localhost:8080/', 'localhost');
+    assert.equal(matched, true);
+  });
+});

--- a/tests/no-proxy-parser-tests.js
+++ b/tests/no-proxy-parser-tests.js
@@ -36,4 +36,34 @@ describe('no proxy variable parsing and matching', () => {
     const matched = NoProxyParseAndMatch('http://localhost:8080/', 'localhost');
     assert.equal(matched, true);
   });
+
+  it('will return false if the no_proxy variable is undefined.', ()=> {
+    const matched = NoProxyParseAndMatch('http://localhost:8080/', undefined);
+    assert.equal(matched, false);
+  });
+
+  it('will return false if the no_proxy variable is null.', ()=> {
+    const matched = NoProxyParseAndMatch('http://localhost:8080/', null);
+    assert.equal(matched, false);
+  });
+
+  it('will return false if the no_proxy variable is an empty string.', ()=> {
+    const matched = NoProxyParseAndMatch('http://localhost:8080/', '');
+    assert.equal(matched, false);
+  });
+
+  it('will return false if the host variable is undefined.', ()=> {
+    const matched = NoProxyParseAndMatch(undefined, 'localhost');
+    assert.equal(matched, false);
+  });
+
+  it('will return false if the host variable is null.', ()=> {
+    const matched = NoProxyParseAndMatch(null, 'localhost');
+    assert.equal(matched, false);
+  });
+
+  it('will return false if the host variable is an empty string.', ()=> {
+    const matched = NoProxyParseAndMatch('', 'localhost');
+    assert.equal(matched, false);
+  });
 });

--- a/tests/proxy-tests.js
+++ b/tests/proxy-tests.js
@@ -105,6 +105,10 @@ describe('test configuration handling', () => {
       proxy.close()
     }
 
+    if(process.env.NO_PROXY) {
+      process.env.NO_PROXY = undefined;
+    }
+
     done()
   })
 
@@ -125,6 +129,39 @@ describe('test configuration handling', () => {
 
         startGateway(baseConfig, (req, res) => {
           assert.equal('localhost:' + proxyPort, req.headers.host)
+          res.end('OK')
+        }, () => {
+          gateway.start((err) => {
+            assert.ok(!err, err)
+
+            request({
+              method: 'GET',
+              url: 'http://localhost:' + gatewayPort + '/v1'
+            }, (err, r, body) => {
+              assert.ok(!err, err)
+              assert.equal(r.statusCode, 200)
+              done()
+            })
+          })
+        })
+      })
+
+      it('will respect the no_proxy variable', (done) => {
+        
+        process.env.NO_PROXY = 'localhost'
+        const baseConfig = {
+          edgemicro: {
+            port: gatewayPort,
+            logging: { level: 'info', dir: './tests/log' },
+            proxy: 'http://localhost:' + proxyPort
+          },
+          proxies: [
+            { base_path: '/v1', secure: false, url: 'http://localhost:' + port }
+          ]
+        }
+
+        startGateway(baseConfig, (req, res) => {
+          assert.equal('localhost:' + port, req.headers.host)
           res.end('OK')
         }, () => {
           gateway.start((err) => {


### PR DESCRIPTION
The proxy server implementation must respect the NO_PROXY variable to override the HTTP_PROXY or HTTPS_PROXY variables.