### PR TITLE
fixing bi-directional ssl support from source

### DIFF
--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -13,7 +13,7 @@ const logging = require('./logging')
 const assert = require('assert')
 const configService = require('./config')
 
-//http server 
+//http server
 var server;
 
 /**
@@ -55,13 +55,14 @@ module.exports.start = function (plugins, cb) {
         ca: config.edgemicro.ssl.ca,
         ciphers: config.edgemicro.ssl.ciphers,
         rejectUnauthorized: config.edgemicro.ssl.rejectUnauthorized,
+        requestCert: config.edgemicro.ssl.requestCert,
         secureProtocol: config.edgemicro.ssl.secureProtocol,
         servername: config.edgemicro.ssl.servername
       }
 
       var key = config.edgemicro.ssl.key;
       var cert = config.edgemicro.ssl.cert;
-      var pfx = config.edgemicro.ssl.pfx; 
+      var pfx = config.edgemicro.ssl.pfx;
 
       if(key && cert) {
         options.key = fs.readFileSync(path.resolve(key), 'utf8');
@@ -81,9 +82,9 @@ module.exports.start = function (plugins, cb) {
       res && res.writeHead(500, {
         'Content-Type': 'application/json'
       })
-      
-      logger.error(err,"failed in error handler");    
-      
+
+      logger.error(err,"failed in error handler");
+
       res && res.end({"message":err});
       cb(err);
     });
@@ -96,7 +97,7 @@ module.exports.start = function (plugins, cb) {
       server.maxConnections = maxConnections
     }
 
-    
+
     if (config.edgemicro.address) {
       server.listen(config.edgemicro.port, config.edgemicro.address, function (err) {
         if (err) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microgateway-core",
-  "version": "2.3.2-beta",
+  "version": "2.3.3",
   "description": "Core engine for Apigee Edge Microgateway",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
While the Apigee Microgateway provides support for bidirectional ssl between itself and the target, there is no support for bidirectional ssl between the source and itself.

I believe that this might have been the intention of a previous commit because part of the options for the https server include `rejectUnauthorized: config.edgemicro.ssl.rejectUnauthorized`. However, according the the Node.js documentation, this option has no effect unless the requestCert option is true. This option is not currently specified in the options. Hence I am adding it.