### PR TITLE
Fix for streaming issues, by leaving stream open.

### DIFF
--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -379,6 +379,17 @@ function _subscribeToResponseEvents(plugins, sourceRequest, sourceResponse, targ
     targetResponse: targetResponse
   }));
 
+  var endStream = true;
+  var accumulatePresent = plugins.some((p) => {
+    return p.id =='accumulate-response';
+  });
+
+  var chunkedTransfer = targetResponse.headers['transfer-encoding'] == 'chunked';
+
+  if(accumulatePresent && chunkedTransfer) {
+    endStream = false;
+  }
+
   var ondata_response_transform = new OnDataTransform({
     pluginHooks: getPluginHooksForEvent('data', {
       plugins: plugins,
@@ -389,15 +400,20 @@ function _subscribeToResponseEvents(plugins, sourceRequest, sourceResponse, targ
     })
   });
 
-  targetResponse.on('end', ()=> {
+  ondata_response_transform.on('end', ()=> {
     onend_response_handlers(empty_buffer,
       function(err, result) {
+        console.log(result);
         if(err) {
           logger.error(err);
         }
 
         if(result && result.length) {
-          sourceResponse.write(result);
+          if(!endStream) {
+            sourceResponse.end(result);
+          } else {
+            sourceResponse.write(result);
+          }
         }
 
         return cb(err, result);
@@ -406,7 +422,7 @@ function _subscribeToResponseEvents(plugins, sourceRequest, sourceResponse, targ
 
   targetResponse
     .pipe(ondata_response_transform)
-    .pipe(sourceResponse);
+    .pipe(sourceResponse, {end: endStream});
 
   targetResponse.on('close', function() {
     debug('targetResponse close', correlation_id);

--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -409,11 +409,9 @@ function _subscribeToResponseEvents(plugins, sourceRequest, sourceResponse, targ
         }
 
         if(result && result.length) {
-          if(!endStream) {
-            sourceResponse.end(result);
-          } else {
-            sourceResponse.write(result);
-          }
+          sourceResponse.end(result);
+        } else {
+          sourceResponse.end();
         }
 
         return cb(err, result);
@@ -422,7 +420,7 @@ function _subscribeToResponseEvents(plugins, sourceRequest, sourceResponse, targ
 
   targetResponse
     .pipe(ondata_response_transform)
-    .pipe(sourceResponse, {end: endStream});
+    .pipe(sourceResponse, {end: 'false'});
 
   targetResponse.on('close', function() {
     debug('targetResponse close', correlation_id);


### PR DESCRIPTION
Solves issue where stream was not finished processing data, but we were executing end handlers anyway. This causes a partial response to be sent.