### PR TITLE
Fix readme's markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-#Microgateway-Core
+# Microgateway-Core
 microgateway-core is a pass through api proxy that events to plugin middleware.  The plugin middleware can implement a variety of functions like oauth, spikearrest, and quotas on your apis.
 
 we have provided some default middleware that you can use in the [microgateway-plugin](https://github.com/apigee/microgateway-plugins) repo.
 
-##Usage
+## Usage
 to use microgateway-core you must initialize microgateway with a config.  the config can be instantiated using the [microgateway-config repo](https://github.com/apigee/microgateway-config).
 
 ```javascript
@@ -26,5 +26,5 @@ config.get({source:'same.yaml',keys:{key: '', secret: ''}},(err,config)=>{
 	});
 });
 ```    
-##more info
+## More info
 for more info on usage we use the microgateway-core to power our microgateway product. we use a command line utility here.  [https://github.com/apigee/microgateway-cli](https://github.com/apigee/microgateway-cli)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Microgateway-Core
-microgateway-core is a pass through api proxy that events to plugin middleware.  The plugin middleware can implement a variety of functions like oauth, spikearrest, and quotas on your apis.
+Microgateway-core is a pass through api proxy that events to plugin middleware. The plugin middleware can implement a variety of functions like oauth, spikearrest, and quotas on your apis.
 
-we have provided some default middleware that you can use in the [microgateway-plugin](https://github.com/apigee/microgateway-plugins) repo.
+We have provided some default middleware that you can use in the [microgateway-plugin](https://github.com/apigee/microgateway-plugins) repo.
 
 ## Usage
-to use microgateway-core you must initialize microgateway with a config.  the config can be instantiated using the [microgateway-config repo](https://github.com/apigee/microgateway-config).
+To use microgateway-core you must initialize microgateway with a config. The config can be instantiated using the [microgateway-config repo](https://github.com/apigee/microgateway-config).
 
 ```javascript
 const config = require('microgateway-config');
@@ -27,4 +27,4 @@ config.get({source:'same.yaml',keys:{key: '', secret: ''}},(err,config)=>{
 });
 ```    
 ## More info
-for more info on usage we use the microgateway-core to power our microgateway product. we use a command line utility here.  [https://github.com/apigee/microgateway-cli](https://github.com/apigee/microgateway-cli)
+For more info on usage we use the microgateway-core to power our microgateway product. We use a command line utility here.  [https://github.com/apigee/microgateway-cli](https://github.com/apigee/microgateway-cli)


### PR DESCRIPTION
I added three strategically-placed spaces.

I also capitalized things, because I like to use the full range of ASCII characters outside of password requirements.