### PR TITLE
Microgateway does not accept NO_PROXY=*.domain.com

### DIFF
--- a/lib/no-proxy-parser.js
+++ b/lib/no-proxy-parser.js
@@ -14,7 +14,30 @@ function parseNoProxy(noProxyVar) {
       port: hostParts[1]
     }
   });
-  return formattedHosts; 
+  return formattedHosts;
+}
+
+/*
+Check if the hostname port matches the no_proxy hostname/port.
+Return true ONLY IF
+1) NO_PROXY port is not included AND the hostname matches the no_proxy hostname.
+2) if NO_PROXY port is included then it matches the hostname port and the hostnames match.
+otherwise return false
+
+i.e.
+foo.com:4000 matches no_proxy: foo.com
+foo.com:4000 matches no_proxy: foo.com:4000
+foo.com:4000 does not match no_proxy: foo.com:3000
+foo.bar.com:4000 matches no_proxy: foo*.com
+foo.bar.com:4000 matches no_proxy: foo*.com:4000
+foo.bar.com:4000 does not match no_proxy: foo*.com:3000
+*/
+function doesPortMatch(hostPort, noproxyPort, hostnamesMatch){
+  if(noproxyPort) {
+    return hostPort == noproxyPort && hostnamesMatch;
+  } else {
+    return hostnamesMatch;
+  }
 }
 
 function matchHostAgainstNoProxy(host, noProxyVar) {
@@ -30,20 +53,22 @@ function matchHostAgainstNoProxy(host, noProxyVar) {
   }
 
   return parsedHosts.some((e) => {
-    var matchIndex = e.host.indexOf(canonicalHost);
-    const match = matchIndex > -1
-
-    var perfectHostMatch = match && (matchIndex == e.host.length - canonicalHost.length);
-
-    if(e.port) {
-      return parsedHostToMatch.port == e.port && perfectHostMatch; 
+    if(e.host.indexOf('*') !== -1 ){
+      //drop the first period that is added by canonicalizeHostname function
+      var hostname = e.host.replace(/./,'');
+      //replace all . with \. ensures the regex pattern looks for the acutal period
+      var escapedPattern = hostname.replace(/\./g,'\\.');
+      escapedPattern = escapedPattern.replace('*','.*');
+      pattern = new RegExp(escapedPattern);
+      var match = pattern.test(canonicalHost);
+      return doesPortMatch(parsedHostToMatch.port, e.port, match);
     } else {
-      return perfectHostMatch;
+      var matchIndex = e.host.indexOf(canonicalHost);
+      const match = matchIndex > -1
+
+      var perfectHostMatch = match && (matchIndex == e.host.length - canonicalHost.length);
+      return doesPortMatch(parsedHostToMatch.port, e.port, perfectHostMatch);
     }
-  });
 }
 
 module.exports = matchHostAgainstNoProxy;
-
-
-

--- a/lib/no-proxy-parser.js
+++ b/lib/no-proxy-parser.js
@@ -69,6 +69,7 @@ function matchHostAgainstNoProxy(host, noProxyVar) {
       var perfectHostMatch = match && (matchIndex == e.host.length - canonicalHost.length);
       return doesPortMatch(parsedHostToMatch.port, e.port, perfectHostMatch);
     }
+});
 }
 
 module.exports = matchHostAgainstNoProxy;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,5 +1,5 @@
 {
   "name": "microgateway-core",
-  "version": "2.5.10",
+  "version": "2.5.11",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microgateway-core",
-  "version": "2.5.10",
+  "version": "2.5.11",
   "description": "Core engine for Apigee Edge Microgateway",
   "main": "index.js",
   "dependencies": {

--- a/tests/no-proxy-parser-tests.js
+++ b/tests/no-proxy-parser-tests.js
@@ -66,7 +66,7 @@ describe('no proxy variable parsing and matching', () => {
     const matched = NoProxyParseAndMatch('', 'localhost');
     assert.equal(matched, false);
   });
-  
+
   it('will parse and match a host when no proxy is comma delimited list', ()=> {
     const matched = NoProxyParseAndMatch('http://localhost/', 'localhost,foo.bar,bar.baz');
     assert.equal(matched, true);
@@ -101,5 +101,93 @@ describe('no proxy variable parsing and matching', () => {
   it('will not partially match hosts with only one in no_proxy list', () => {
     const matched = NoProxyParseAndMatch('http://foo/', 'foo.bar');
     assert.equal(matched, false);
+  });
+
+  it('will check if no_proxy (*foo.com) matches foo.com', () => {
+    const matched = NoProxyParseAndMatch('http://foo.com/', '*foo.com');
+    assert.equal(matched, true);
+  });
+
+  it('will check if no_proxy (....foo.com) does not match testing.foo.com', () => {
+    const matched = NoProxyParseAndMatch('http://testing.foo.com/', '....foo.com');
+    assert.equal(matched, false);
+  });
+
+  it('will check if no_proxy (*.foo.com) matches testing.foo.com', () => {
+    const matched = NoProxyParseAndMatch('http://testing.foo.com/', '*.foo.com');
+    assert.equal(matched, true);
+  });
+
+  it('will check if no_proxy matches testing.foo2.com and hostname should not match', () => {
+    const matched = NoProxyParseAndMatch('http://testing.foo2.com/', '*.foo.com');
+    assert.equal(matched, false);
+  });
+
+  it('will check if no_proxy matches testing.foobcom does not match testing.foobcom', () => {
+    const matched = NoProxyParseAndMatch('http://testing.foobcom/', '*.foo.com');
+    assert.equal(matched, false);
+
+  });
+
+  it('will check if no_proxy = localhost,*.foo.com does not match hostname = testing.bar.com', () => {
+    const matched = NoProxyParseAndMatch('http://testing.bar.com/', 'localhost,*.foo.com');
+    assert.equal(matched, false);
+
+  });
+
+  it('will check if no_proxy has localhost,*.foo.com matches hostname testing.foo.com', () => {
+    const matched = NoProxyParseAndMatch('http://testing.foo.com/', 'localhost,*.foo.com');
+    assert.equal(matched, true);
+
+  });
+
+  it('will check if no_proxy has localhost,*.foo.com does not match hostname testing.foobcom', () => {
+    const matched = NoProxyParseAndMatch('http://testing.foobcom/', 'localhost,*.foo.com');
+    assert.equal(matched, false);
+
+  });
+
+
+  it('will check if no_proxy has localhost,.foo*.com matches hostname testing.foo.hello.com', () => {
+    const matched = NoProxyParseAndMatch('http://testing.foo.hello.com/', 'localhost,.foo*.com');
+    assert.equal(matched, true);
+
+  });
+
+  it('will check if no_proxy has localhost,foo*.com and hostname testing-foo.hello.com', () => {
+    const matched = NoProxyParseAndMatch('http://testing-foo.hello.com/', 'localhost,foo*.com');
+    assert.equal(matched, true);
+
+  });
+
+
+  it('will check if no_proxy has foo*.com:4000 does not match hostname testing-foo.hello.com', () => {
+    const matched = NoProxyParseAndMatch('http://testing-foo.hello.com/', 'foo*.com:4000');
+    assert.equal(matched, false);
+
+  });
+
+  it('will check if no_proxy has foo*.com:4000 matches hostname testing-foo.hello.com:4000', () => {
+    const matched = NoProxyParseAndMatch('http://testing-foo.hello.com:4000/', 'foo*.com:4000');
+    assert.equal(matched, true);
+
+  });
+
+  it('will check if no_proxy has localhost,checkers.part.com,foo*.com:4000 matches hostname testing-foo.hello.com:4000', () => {
+    const matched = NoProxyParseAndMatch('http://testing-foo.hello.com:4000/', 'localhost,checkers.part.com,foo*.com:4000');
+    assert.equal(matched, true);
+
+  });
+
+  it('will check if no_proxy has localhost,checkers.part.com,foo*.com matches hostname testing-foo.hello.com:4000', () => {
+    const matched = NoProxyParseAndMatch('http://testing-foo.hello.com:4000/', 'localhost,checkers.part.com,foo*.com');
+    assert.equal(matched, true);
+
+  });
+
+  it('will check if no_proxy has localhost,checkers.part.com,foo*.com:4000,testing-bar.hello.com matches hostname testing-bar.hello.com', () => {
+    const matched = NoProxyParseAndMatch('http://testing-bar.hello.com/', 'localhost,checkers.part.com,foo*.com:4000,testing-bar.hello.com');
+    assert.equal(matched, true);
+
   });
 });


### PR DESCRIPTION
We have a client that is using PCF and PCF allows developers to create new URLs for each app that they create.   The current implementation of Edge Microgateway requires users to explicitly list all domains in the NO_PROXY environment variable (i.e. NO_PROXY=app1.pcf.domain.com, app2.pcf.domain.com,app3.pcf.domain.com).

This is a significant burden on PCF developers using Edge Microgateway.  The solutions is to allow a wildcard (*) parameter in the domains listed in the NO_PROXY environment variable.  

This pull requests allows developers to use * as a wildcard in the NO_PROXY environment variable.
For example:
foo.com:4000 **matches** no_proxy: foo.com
foo.com:4000 **matches** no_proxy: foo.com:4000
foo.com:4000 **does not match** no_proxy: foo.com:3000
foo.bar.com:4000 **matches** no_proxy: foo*.com
foo.bar.com:4000 **matches** no_proxy: foo*.com:4000
foo.bar.com:4000 **does not match** no_proxy: foo*.com:3000
foo.bar.com **matches** no_proxy: *.bar.com
