### PR TITLE
add content-length setting

### DIFF
--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -194,7 +194,7 @@ function getTargetRequest(sourceRequest, sourceResponse, plugins, startTime, cor
             delete target_headers.host;
         }
 
-        if (target_headers['content-length']) {
+        if (target_headers['content-length'] && config.edgemicro.contentlength!==true) {
             delete target_headers['content-length'];
         }
     }
@@ -425,6 +425,10 @@ function subscribeToSourceRequestEvents(plugins, sourceRequest, sourceResponse, 
                 }
 
                 if (result && result.length) {
+                    if (plugins.some(p => p.id == 'contentlength')) {
+                        debug('writing content-length header');
+                        targetRequest.setHeader('content-length', Buffer.byteLength(result));
+                    }
                     targetRequest.write(result)
                 }
             });


### PR DESCRIPTION
b127687184
Adds support for targets accepting content-length only. 
1. edgemicro.contentlength is used if the content-length is supplied and body is not transformed
2. plugins - contentlength is used if the body is transformed
edgemicro:
   contentlength: true
   plugins:
     sequence:
       - oauth
       - contentlength 