### PR TITLE
Adding code for keepAliveTimeout

### DIFF
--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -157,7 +157,12 @@ module.exports.start = function(plugins, cb) {
                 cb(null, server)
             })
         }
-
+        // set the keepalive timeout because Google likes 10mins
+       // and if you don't the 502s come hard with no real reason
+       const keepAliveTimeout = config.edgemicro.keep_alive_timeout
+       if (keepAliveTimeout && typeof keepAliveTimeout === 'number' && keepAliveTimeout > 0) {
+           server.keepAliveTimeout = keepAliveTimeout
+       }
     } catch (err) {
         cb(err)
     }


### PR DESCRIPTION
If requests are coming from Google Load Balancer occasionally you will see 502 response codes. This happens because the GCLB has a timeout of 10 mins. This can not be changed. The microgateway has a timeout less than what Google's timeout is so it is closing connections before the GCLB resulting in the 502s. Another change will be proposed to allow this to be configured from the configuration file.