### PR TITLE
Add configurable keepAliveTimeout

### DIFF
--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -133,6 +133,13 @@ module.exports.start = function(plugins, cb) {
             server.maxConnections = maxConnections
         }
 
+        // place a configurable limit on keepAliveTmieout (if configured)
+        // this solve the problem of having microgateway behind a load balancer and sporadic 502s
+        // see https://nodejs.org/api/http.html#http_server_keepalivetimeout
+        const keepAliveTimeout = config.edgemicro.keep_alive_timeout
+        if (keepAliveTimeout && typeof keepAliveTimeout === 'number' && keepAliveTimeout > 0) {
+            server.keepAliveTimeout = keepAliveTimeout
+        }
 
         if (config.edgemicro.address) {
             server.listen(config.edgemicro.port, config.edgemicro.address, function(err) {

--- a/tests/config.yaml
+++ b/tests/config.yaml
@@ -11,6 +11,7 @@ edgemicro:
   port: 8000
   max_connections: -1
   max_connections_hard: -1
+  keep_alive_timeout: 5000
   debug:
     port: 5999
     args: '--nolazy'


### PR DESCRIPTION
This solves an error where a load balancer will try to use a connection
that node has closed. In GCP, this erorr shows up in the logs as:
backend_connection_closed_before_data_sent_to_client
Google's documentation states that their keepalive time is set to 10mins
and to try setting your server time to greater than that. This enables
microgateway to set that (beyond the 5sec default) and be configurable
based on a clients needs.

Details:
https://blog.percy.io/tuning-nginx-behind-google-cloud-platform-http-s-load-balancer-305982ddb340
https://cloud.google.com/load-balancing/docs/https/https-logging-monitoring