### PR TITLE
Passing object instead of String

### DIFF
--- a/lib/logging.js
+++ b/lib/logging.js
@@ -131,7 +131,7 @@ module.exports.init = function init(stubConfig, options) {
       }
        return rec;
     }
-    return logger.writeLogRecord(serializeLogRecord(level, logConfig.level, obj, msg, isTransactionLog));
+    return logger.writeLogRecord({msg:serializeLogRecord(level, logConfig.level, obj, msg, isTransactionLog)});
   }
   logger = {
     info: function (obj, msg) {


### PR DESCRIPTION
The writeLogRecord function of logger is expecting object with 'msg' as string to be logged in fle.
So if just string is passed to writeLogRecord then it is ignored.