### PR TITLE
Add format to console logs

### DIFF
--- a/lib/logging.js
+++ b/lib/logging.js
@@ -209,7 +209,7 @@ const writeConsoleLog = function (level, obj, ...dataList) {
       component = obj.component;
     }
     let message = Timestamp + ' ['+ ProcessId + ']'+ ' ['+ component + ']';
-      console[level](message,...dataList);
+      console[level](message, util.format(...dataList));
   }
 }
 


### PR DESCRIPTION
Use node library 'util' to add printf-like format to console logs.