### PR TITLE
Added config option to keep content enconding

### DIFF
--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -199,12 +199,15 @@ function getTargetRequest(sourceRequest, sourceResponse, plugins, startTime, cor
             delete target_headers.host;
         }
 
-        if (target_headers['content-length']) {
+        // only enable keepTransferEncoding, if the http body is not modified by any of the configured plugins
+        const keepTransferEncoding = config.edgemicro.keep_transfer_encoding;
+        if ( !keepTransferEncoding && target_headers['content-length']) {
             delete target_headers['content-length'];
             if(!target_headers['transfer-encoding'] && sourceRequest.method==='DELETE') {
                 target_headers['transfer-encoding'] = 'chunked';
             }
         }
+       
     }
 
     var httpLibrary = http;


### PR DESCRIPTION
Added a config option to preserve the content encoding set by the client. This prevents that southbound request from the gateway are always using chunked-encoding. When enabled southbound request will use content-lenght if the client did send that header. 

This option should only be set if all active plugins don't do any http body modifications. 

Config Option:

edgemicro:
  keep_transfer_encoding: true  #(default: false)