### PR TITLE
For310 logging changes

### DIFF
--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -29,7 +29,7 @@ module.exports = function(plugins) {
     const logger = logging.getLogger();
 
     return function(sourceRequest, sourceResponse, next) {
-        const startTime = Date.now();
+        const startTime = sourceRequest.reqStartTimestamp ||  Date.now();
         const correlation_id = uuid.v1();
         sourceRequest['correlationId'] = correlation_id;
         logger.setTransactionContext( correlation_id,sourceRequest);
@@ -79,7 +79,8 @@ module.exports = function(plugins) {
                     //closetrace
                     
                     //create target request
-                    const targetRequest = getTargetRequest(sourceRequest, sourceResponse, plugins, startTime, correlation_id,
+                    const targetStartTime = Date.now();
+                    const targetRequest = getTargetRequest(sourceRequest, sourceResponse, plugins, targetStartTime, correlation_id,
                         //callback for when response is initiated
                         (err, targetResponse) => {
 
@@ -88,6 +89,7 @@ module.exports = function(plugins) {
                             }
                             const options = {
                                 start: startTime,
+                                targetStartTime: targetStartTime,
                                 correlation_id: correlation_id,
                                 plugins: plugins,
                                 sourceRequest: sourceRequest,
@@ -312,7 +314,7 @@ function getTargetRequest(sourceRequest, sourceResponse, plugins, startTime, cor
  * @private
  */
 function handleTargetResponse(targetRequest, targetResponse, options, cb) {
-    const start = options.start;
+    const start = options.targetStartTime;
     const correlation_id = options.correlation_id;
     var copyOfPluginsReversed = options.plugins.slice().reverse();
     const plugins = copyOfPluginsReversed;
@@ -321,13 +323,6 @@ function handleTargetResponse(targetRequest, targetResponse, options, cb) {
     const logger = logging.getLogger();
     const config = configService.get();
 
-    logger.eventLog({
-        level:'debug',
-        res: targetResponse,
-        req: targetRequest,
-        d: Date.now() - start,
-        component:'plugins-middleware'
-    }, 'targetResponse');
     debug('targetResponse', correlation_id, targetResponse.statusCode);
     async.series(
         //onresponse
@@ -339,6 +334,14 @@ function handleTargetResponse(targetRequest, targetResponse, options, cb) {
             targetResponse: targetResponse
         }),
         function(err, results) {
+            logger.eventLog({
+                level:'debug',
+                res: targetResponse,
+                req: targetRequest,
+                d: Date.now() - ( sourceRequest.headers['target_sent_start_timestamp'] || start ),
+                component:'plugins-middleware'
+            }, 'targetResponse');
+
             if ( err ) logger.eventLog({level:'error', res: sourceResponse, err: err,component:'plugins-middleware'},"");
             if (sourceResponse.finished || sourceResponse.headersSent) {
                 logger.eventLog({level:'error', res: sourceResponse, err: err,component:'plugins-middleware'},"response finished before work can be done");
@@ -382,7 +385,7 @@ function handleTargetResponse(targetRequest, targetResponse, options, cb) {
             if (_configured(config, 'x-response-time')) {
                 sourceResponse.setHeader('x-response-time', Date.now() - start);
             }
-            _subscribeToResponseEvents(plugins, sourceRequest, sourceResponse, targetRequest, targetResponse, correlation_id, start,
+            _subscribeToResponseEvents(plugins, sourceRequest, sourceResponse, targetRequest, targetResponse, correlation_id, options,
                 function(err, result) {
                     cb(err, result)
                 });
@@ -452,8 +455,10 @@ function subscribeToSourceRequestEvents(plugins, sourceRequest, sourceResponse, 
  * @param cb
  * @private
  */
-function _subscribeToResponseEvents(plugins, sourceRequest, sourceResponse, targetRequest, targetResponse, correlation_id, start, cb) {
+function _subscribeToResponseEvents(plugins, sourceRequest, sourceResponse, targetRequest, targetResponse, correlation_id, options, cb) {
     const logger = logging.getLogger();
+    const start = options.start;
+    const targetStartTime = options.targetStartTime || start;
     //
     // using apply on the array returned by getPluginHooksForEvent --> using a dummy object in place of this, which cannot be bound here.
     const onend_response_handlers = async.seq.apply({}, getPluginHooksForEvent('end', {
@@ -500,7 +505,7 @@ function _subscribeToResponseEvents(plugins, sourceRequest, sourceResponse, targ
                 logger.eventLog({
                     level:'info',
                     res: sourceResponse,
-                    d: Date.now() - start,
+                    d: Date.now() - sourceRequest.reqStartTimestamp || start,
                     component:'plugins-middleware'
                 }, 'sourceResponse' );
 
@@ -520,7 +525,7 @@ function _subscribeToResponseEvents(plugins, sourceRequest, sourceResponse, targ
         logger.eventLog({
             level:'error',
             res: targetResponse,
-            d: Date.now() - start,
+            d: Date.now() - ( sourceRequest.headers['target_sent_start_timestamp'] || targetStartTime ),
             err: err,
             component:'plugins-middleware'
         }, 'targetResponse close');
@@ -530,7 +535,7 @@ function _subscribeToResponseEvents(plugins, sourceRequest, sourceResponse, targ
         logger.eventLog({
             level:'error',
             res: targetResponse,
-            d: Date.now() - start,
+            d: Date.now() - ( sourceRequest.headers['target_sent_start_timestamp'] || targetStartTime ),
             err: err,
             component:'plugins-middleware'
         }, 'targetResponse error');

--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -55,7 +55,7 @@ module.exports = function(plugins) {
             return next(false);
         } else {
             logger.eventLog({
-                level:'debug',
+                level:'info',
                 component:'plugins-middleware'
             }, 'sourceRequest');
             debug('sourceRequest', correlation_id, sourceRequest.method, sourceRequest.url);
@@ -294,7 +294,7 @@ function getTargetRequest(sourceRequest, sourceResponse, plugins, startTime, cor
     });
 
     const logInfo = {
-        level: 'debug',
+        level: 'info',
         req: targetRequest,
         component:'plugins-middleware'
     };
@@ -335,7 +335,7 @@ function handleTargetResponse(targetRequest, targetResponse, options, cb) {
         }),
         function(err, results) {
             logger.eventLog({
-                level:'debug',
+                level:'info',
                 res: targetResponse,
                 req: targetRequest,
                 d: Date.now() - ( sourceRequest.headers['target_sent_start_timestamp'] || start ),


### PR DESCRIPTION
Update logs in plugins middleware to correct the latency value to match with the analytics data.
Change log level of 'sourceRequest','targetRequest' and 'targetResponse' to 'info'.