### PR TITLE
Add error handling to logger

### DIFF
--- a/lib/logging.js
+++ b/lib/logging.js
@@ -277,7 +277,11 @@ function serializeLogRecord(level, configLevel, obj, text, isTransactionLog, sta
         record.u = req.url || req.path;
         record.h = (req.headers ? req.headers.host : '');
         if (!record.h && req.agent && req.agent.sockets) {
-          record.h = Object.keys(req.agent.sockets)[0].replace(':',''); // used if req is target request object
+          let socketdata = Object.keys(req.agent.sockets)[0];
+          if ( socketdata ) {
+            record.h = socketdata.replace(':',''); // used if req is target request object
+          }
+          
         }
         
       }


### PR DESCRIPTION
Add null check on 'req.agent.sockets[0]' while reading hostname from request object to
print in event log.