### PR TITLE
149101890 Correct log level

### DIFF
--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -525,12 +525,10 @@ function _subscribeToResponseEvents(plugins, sourceRequest, sourceResponse, targ
 
     targetResponse.on('close', function() {
         debug('targetResponse close', correlation_id);
-        const err = Error('targetResponse closed');
         logger.eventLog({
-            level:'error',
+            level:'info',
             res: targetResponse,
             d: Date.now() - ( sourceRequest.headers['target_sent_start_timestamp'] || targetStartTime ),
-            err: err,
             component:'plugins-middleware'
         }, 'targetResponse close');
     });


### PR DESCRIPTION
Change log level from 'error' to 'info' for 'targetResponse closed' log.