### PR TITLE
151285018 Add proxy configs in edgemicro

### DIFF
--- a/lib/config-proxy-middleware.js
+++ b/lib/config-proxy-middleware.js
@@ -25,9 +25,11 @@ const sanitizer = require('sanitizer');
 module.exports = function() {
 
     const config = configService.get();
-    //TODO: Respect HTTP_PROXY and HTTPS_PROXY
-    const httpProxyConfig = config.edgemicro.proxy;
-    const httpProxyTunnelConfig = config.edgemicro.proxy_tunnel;
+   
+    const httpProxyConfig = config.edgemicro.proxy ? config.edgemicro.proxy.url : null;
+    const httpProxyTunnelConfig = config.edgemicro.proxy ? config.edgemicro.proxy.tunnel : false;
+    const noProxy = ( config.edgemicro.proxy && config.edgemicro.proxy.bypass ) ? config.edgemicro.proxy.bypass :
+     ( process.env.NO_PROXY || process.env.no_proxy ); // use env variable if edgemicro.proxy.bypass is not set
 
     if (config && config.proxies) {
         config.proxies.forEach(function(proxy) {
@@ -81,9 +83,8 @@ module.exports = function() {
                 // check for client ssl options
             }
 
-            var noProxy = process.env.NO_PROXY || process.env.no_proxy;
-            const shouldntUseProxy = checkNoProxy(proxy.url, noProxy);
-            if (httpProxyConfig && (httpProxyTunnelConfig || secure) && !shouldntUseProxy) {
+            proxy.shouldntUseProxy = !config.edgemicro.proxy || !config.edgemicro.proxy.enabled  || checkNoProxy(proxy.url, noProxy);
+            if (httpProxyConfig && (httpProxyTunnelConfig || secure) && !proxy.shouldntUseProxy) {
                 const tunnelAgent = buildTunnelAgent(httpProxyConfig, opts, proxy);
                 proxy.agent = tunnelAgent;
                 proxy.tunnelEnabled = true;

--- a/lib/config.js
+++ b/lib/config.js
@@ -16,14 +16,16 @@ configService.init = (newConfig) => {
 
   //Iterate through each proxy variable. If it's present in the environment let's place 
   //it in the edgemicro configuration.
-  //If NO_PROXY is set then do not respect those variables
-  var httpProxyEnvVariables = ['HTTP_PROXY', 'HTTPS_PROXY', 'http_proxy', 'https_proxy'];
-  var noProxy = process.env.NO_PROXY || process.env.no_proxy; 
-  httpProxyEnvVariables.forEach((v)=> {
-    if(process.env[v]) {
-      config.edgemicro.proxy = process.env[v];
-    }
-  });
+  // Use proxy from env variables if edgemicro.proxy.url is not set
+  if ( config.edgemicro.proxy && config.edgemicro.proxy.enabled === true && !config.edgemicro.proxy.url ) { 
+    var httpProxyEnvVariables = ['HTTP_PROXY', 'HTTPS_PROXY', 'http_proxy', 'https_proxy'];
+    httpProxyEnvVariables.forEach((v)=> {
+      if(process.env[v]) {
+        config.edgemicro.proxy.url = process.env[v];
+      }
+    });
+  }
+ 
 
   config.targets.forEach(function(target) {
     if ( (typeof target.ssl !== 'object') || (typeof target.ssl.client !== 'object') ) {

--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -224,15 +224,13 @@ function getTargetRequest(sourceRequest, sourceResponse, plugins, startTime, cor
         agent: proxy.agent
     };
 
-    const httpProxyConfig = config.edgemicro.proxy;
-    const httpProxyTunnelConfig = config.edgemicro.proxy_tunnel;
-
+    const httpProxyConfig = config.edgemicro.proxy ? config.edgemicro.proxy.url : null;
+   
     //If we have a proxy configuration, but we aren't tunneling. 
     //Rewrite target request options to account for proxy configuration
 
-    var noProxy = process.env.NO_PROXY || process.env.no_proxy;
-    const shouldntUseProxy = checkNoProxy(proxy.url, noProxy);
-    if (httpProxyConfig && !httpProxyTunnelConfig && !shouldntUseProxy) {
+    
+    if ( httpProxyConfig && !proxy.tunnelEnabled && !proxy.shouldntUseProxy) {
         targetRequestOptions = buildNonTunnelOptions(proxy, targetRequestOptions, httpProxyConfig);
     }
 

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -53,12 +53,6 @@ Plugins.prototype.loadPlugin = function (options) {
       subconfig.key = config.keys.key;
       subconfig.secret = config.keys.secret;
     }
-    if(config.edgemicro.proxy_tunnel) {
-      subconfig.request = {
-        tunnel: config.edgemicro.proxy_tunnel
-      };
-    }
-
     if(name==='quota') {
       subconfig.proxies = config.proxies;
       subconfig.product_to_proxy = config.product_to_proxy;

--- a/tests/proxy-tests-tls.js
+++ b/tests/proxy-tests-tls.js
@@ -119,7 +119,10 @@ describe('test configuration handling', () => {
           edgemicro: {
             port: gatewayPort,
             logging: { level: 'info', dir: './tests/log' },
-            proxy: 'https://localhost:' + proxyPort
+            proxy: {
+              url: 'https://localhost:' + proxyPort,
+              enabled: true
+            }
           },
           proxies: [
             { base_path: '/v1', secure: false, url: 'http://localhost:' + port }
@@ -163,8 +166,11 @@ describe('test configuration handling', () => {
           edgemicro: {
             port: gatewayPort,
             logging: { level: 'info', dir: './tests/log' },
-            proxy: 'https://localhost:' + proxyPort,
-            proxy_tunnel: false
+            proxy: {
+              url: 'https://localhost:' + proxyPort,
+              enabled: true,
+              tunnel: false
+            }
           },
           proxies: [
             { base_path: '/v1', secure: false, url: 'http://localhost:' + port }
@@ -211,8 +217,11 @@ describe('test configuration handling', () => {
           edgemicro: {
             port: gatewayPort,
             logging: { level: 'info', dir: './tests/log' },
-            proxy: 'https://localhost:' + proxyPort,
-            proxy_tunnel: true
+            proxy: {
+              url: 'https://localhost:' + proxyPort,
+              enabled: true,
+              tunnel: true
+            }
           },
           proxies: [
             { base_path: '/v1', secure: false, url: 'http://localhost:' + port }


### PR DESCRIPTION
Separated proxy server configs for edge and target calls.

For edge calls:

Use only environment variables HTTP_PROXY/http_proxy or HTTPS_PROXY/https_proxy to use a proxy server for calls to edge.
Previous configs edge_config.proxy and edge_config.proxy_tunnel are no longer applicable.

For target calls:

Add proxy configs to 'edgemicro' section to proxy the target calls. Below is an example:

edgemicro:
  proxy:
    tunnel: true
    url: 'http://192.168.2.178:3128'
    bypass: 'localhost' # target hosts to bypass the proxy.
    enabled: true

If edgemiro.proxy.enabled is 'true' and proxy.url is not set,
env variables HTTP_PROXY/http_proxy and HTTPS_PROXY/https_proxy will be used.

If edgemicro.proxy.enabled is set 'true' but no url or env variables HTTP_PROXY is defined,
Edgemicro will fail to start with assert error.

If edgemicro.proxy.bypass is not set, env variable NO_PROXY will be used.

If edgemicro.proxy is not defined or edgemicro.proxy.enabled is set 'false',
proxy will not be used on target calls.

Update unit tests cases for the new configs added.