### PR TITLE
152005003 Pass org and env to quota plugin

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -56,6 +56,7 @@ Plugins.prototype.loadPlugin = function (options) {
     if(name==='quota') {
       subconfig.proxies = config.proxies;
       subconfig.product_to_proxy = config.product_to_proxy;
+      subconfig.global = config.edgemicro.global;
     }
     middleware = plugin(subconfig, logger, stats);
     assert(_.isObject(middleware), 'ignoring invalid plugin handlers ' + name);


### PR DESCRIPTION
Pass 'config.edgemicro.global' to the quota plugin subconfig.
The 'config.edgemicro.global' has org and env values.