### PR TITLE
155077210 Correctly print target hostname in logs

### DIFF
--- a/lib/logging.js
+++ b/lib/logging.js
@@ -178,6 +178,10 @@ module.exports.init = function init(stubConfig, options) {
       if ( !isValidIPaddress(clientIP) ) {
         clientIP = '';
       }
+      let targetPortStr = '';
+      if ( !isNaN(parseInt(sourceRequest.targetPort)) ) {
+        targetPortStr = ':'+ parseInt(sourceRequest.targetPort);
+      }
       sourceRequest.transactionContextData = {
         correlation_id: correlation_id,
         method: sourceRequest.method,
@@ -185,7 +189,8 @@ module.exports.init = function init(stubConfig, options) {
         host: (sourceRequest.headers ? sourceRequest.headers.host : ''),
         clientId: (sourceRequest.headers ? sourceRequest.headers['x-api-key'] : ''),
         remoteAddress: (sourceRequest.socket ? (sourceRequest.socket.remoteAddress + ':' + sourceRequest.socket.remotePort) : ':0'),
-        clientIP: clientIP
+        clientIP: clientIP,
+        targetHostName: sourceRequest.targetHostname + targetPortStr
     }
     }
   };

--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -263,8 +263,9 @@ function getTargetRequest(sourceRequest, sourceResponse, plugins, startTime, cor
         logger.eventLog({level:'warn',
             d: Date.now() - startTime,
             err: err,
-            req: sourceRequest,
-            component:'plugins-middleware'
+            h: sourceRequest.transactionContextData.targetHostName,
+            component:'plugins-middleware',
+            transactionContextData: sourceRequest.transactionContextData
         }, 'targetRequest error');
         debug('targetRequest error', correlation_id, err.stack);
         async.series(getPluginHooksForEvent('error', {
@@ -299,7 +300,7 @@ function getTargetRequest(sourceRequest, sourceResponse, plugins, startTime, cor
 
     const logInfo = {
         level: 'info',
-        req: targetRequest,
+        h: sourceRequest.transactionContextData.targetHostName,
         component:'plugins-middleware',
         transactionContextData: sourceRequest.transactionContextData
     };
@@ -342,7 +343,7 @@ function handleTargetResponse(targetRequest, targetResponse, options, cb) {
             logger.eventLog({
                 level:'info',
                 res: targetResponse,
-                req: targetRequest,
+                h: sourceRequest.transactionContextData.targetHostName,
                 d: Date.now() - ( sourceRequest.headers['target_sent_start_timestamp'] || start ),
                 component:'plugins-middleware',
                 transactionContextData: sourceRequest.transactionContextData
@@ -531,8 +532,10 @@ function _subscribeToResponseEvents(plugins, sourceRequest, sourceResponse, targ
         logger.eventLog({
             level:'info',
             res: targetResponse,
+            h: sourceRequest.transactionContextData.targetHostName,
             d: Date.now() - ( sourceRequest.headers['target_sent_start_timestamp'] || targetStartTime ),
-            component:'plugins-middleware'
+            component:'plugins-middleware',
+            transactionContextData: sourceRequest.transactionContextData
         }, 'targetResponse close');
     });
 
@@ -540,9 +543,11 @@ function _subscribeToResponseEvents(plugins, sourceRequest, sourceResponse, targ
         logger.eventLog({
             level:'error',
             res: targetResponse,
+            h: sourceRequest.transactionContextData.targetHostName,
             d: Date.now() - ( sourceRequest.headers['target_sent_start_timestamp'] || targetStartTime ),
             err: err,
-            component:'plugins-middleware'
+            component:'plugins-middleware',
+            transactionContextData: sourceRequest.transactionContextData
         }, 'targetResponse error');
 
         debug('targetResponse error', correlation_id, err.stack);

--- a/tests/target-behavior.js
+++ b/tests/target-behavior.js
@@ -87,6 +87,9 @@ describe('target behavior', () => {
             'targetSecure' : false,
             'targetHostname' : 'localhost',
             'targetPort' : 8888,
+            transactionContextData: {
+                'targetHostName' : 'localhost'
+            }
         }
 
         var sourceResponse = {
@@ -163,6 +166,9 @@ describe('target behavior', () => {
             'targetSecure' : false,
             'targetHostname' : 'this.does.not.exist',
             'targetPort' : 8999,
+            transactionContextData: {
+                'targetHostName' : 'this.does.not.exist'
+            }
         }
 
         var sourceResponse = {
@@ -245,6 +251,9 @@ describe('target behavior', () => {
                 'targetSecure' : false,
                 'targetHostname' : 'localhost',
                 'targetPort' : 8999,
+                transactionContextData: {
+                    'targetHostName' : 'this.does.not.exist'
+                }
             }
 
             var sourceResponse = {


### PR DESCRIPTION
Add target hostname in 'transactionContextData' and use that to correctly print target hostname in event logs.