### PR TITLE
156560067 Read ssl values from env variables

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -32,6 +32,13 @@ configService.init = (newConfig) => {
       return;
     }
 
+    // merge the targets ssl client env values in the config
+    if ( target.ssl.useEnv ) {
+      Object.keys(target.ssl.client).forEach( key => {
+          let envName = target.ssl.client[key];
+          target.ssl.client[key] = process.env[envName];
+      })
+    }
     // restrict the copied options to prevent target hijacking
     // via configuration
     target.ssl.client.httpsOptions = {


### PR DESCRIPTION
If targets.ssl.useEnv is set to true, read values for targets.ssl.client from the env varialbe where the initial value is env variable name.

An example config is as below:

targets:
  - ssl:
      useEnv: true
      client:
        key: TARGETS_SSL_CLIENT_KEY
        cert: TARGETS_SSL_CLIENT_CERT
        passphrase: TARGETS_SSL_CLIENT_PASSPHRASE
        rejectUnauthorized: TARGETS_SSL_CLIENT_REJECT_UNAUTH

Here the initial values are actually env varialbe names.