### PR TITLE
158529279 Remove duplicate headers

### DIFF
--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -142,6 +142,17 @@ function getTargetRequest(sourceRequest, sourceResponse, plugins, startTime, cor
     //capture the timestamp just before sending the data to the target server
     sourceRequest.headers['target_sent_start_timestamp'] = Date.now();
 
+    // remove duplicate headers
+    Object.keys(sourceRequest.headers).forEach( h=> {
+        let lowercaseHeader = h.toLowerCase();
+        if ( lowercaseHeader!== h && sourceRequest.headers[lowercaseHeader]) { // two headers are present
+            logger.eventLog({level:'info',req: sourceRequest, res: sourceResponse, err: null,component:'plugins-middleware'},
+            'deleting duplicate header '+lowercaseHeader);
+            delete sourceRequest.headers[lowercaseHeader];
+        }
+    })
+
+
     // try to pass through most of the original request headers unmodified
     const target_headers = _.clone(sourceRequest.headers);
     //create request id only if the source doesn't have it.


### PR DESCRIPTION
Remove lowercase header if another header is present before sending to target.

example duplicate headers could be:

content-type: 'application/xml'
Content-Type: 'application/json'