### PR TITLE
Add excludeUrls feature

### DIFF
--- a/lib/PluginsSeqManager.js
+++ b/lib/PluginsSeqManager.js
@@ -1,0 +1,103 @@
+const debug = require('debug')('plugins-seq-manager')
+
+
+class PluginsSeqManager {
+
+    constructor(config, plugins){
+        this.plugins = plugins;
+        this.config = config;
+        this.urlPluginsCache = new Map();
+        this.defaultPlugins = plugins.filter( p => p.id === 'analytics' || p.id === 'metrics');
+        this.uniqueUrls = new Set();
+        
+        if ( this.config.edgemicro.plugins && this.config.edgemicro.plugins.disableExcUrlsCache !== true ) {
+            debug('Loading all plugins exclude urls in memory');
+            this.loadAllUrls();
+        } else {
+            if (  this.config.edgemicro.plugins && this.config.edgemicro.plugins.excludeUrls  ) {
+                this.config.edgemicro.plugins.excludeUrls.split(',').forEach( url =>    this.uniqueUrls.add(url) )
+            }
+            this.plugins.forEach( p => {
+                if ( p.id !== 'analytics' && p.id !== 'metrics'  && this.config[p.id] && this.config[p.id].excludeUrls  ) {
+                    this.config[p.id].excludeUrls.split(',').forEach( url => this.uniqueUrls.add(url));
+                }
+            });
+            debug('Unique exclude urls', Array.from(this.uniqueUrls));
+        }
+    }
+
+    loadAllUrls() {
+
+        // load global excludeUrls
+        if (  this.config.edgemicro.plugins && this.config.edgemicro.plugins.excludeUrls  ) {
+            this.config.edgemicro.plugins.excludeUrls.split(',').forEach( url => {
+                this.urlPluginsCache.set(url, {
+                    plugins: this.defaultPlugins,
+                    isGlobal: true
+                });
+            })
+        }
+        // load urls from the plugins which are enabled in sequence. 
+        this.plugins.forEach( p => {
+            if ( p.id !== 'analytics' && p.id !== 'metrics'  && this.config[p.id] ) {
+                let excludeUrls = null;
+                if ( this.config[p.id].excludeUrls ) {
+                    excludeUrls = this.config[p.id].excludeUrls;
+                } else if ( p.id === 'quota' && this.config['quotas'] && this.config['quotas'].excludeUrls ) {
+                    excludeUrls = this.config['quotas'].excludeUrls;
+                }
+                if (excludeUrls) {
+                    excludeUrls.split(',').forEach( url => {
+                            if ( !this.urlPluginsCache.has(url)) {
+                                // skip this plugin
+                                this.urlPluginsCache.set(url, {
+                                    plugins:  this.plugins.filter( plgn => plgn.id !== p.id)
+                                });
+                            } else {
+                                let value = this.urlPluginsCache.get(url);
+                                this.urlPluginsCache.set(url, {
+                                    plugins:  value.plugins.filter( plgn => plgn.id !== p.id)
+                                });
+                            }
+                        }
+                    );
+                }
+
+            }
+        });
+        debug('Total urls loaded: %d', this.urlPluginsCache.size);
+        for (let [url, value] of this.urlPluginsCache) {
+            debug('url: %s, plugins:',url,value.plugins.map(p=>p.id));
+        }
+    }
+
+    getPluginSequence(url){
+
+        if ( this.urlPluginsCache.has(url) ) {
+            return this.urlPluginsCache.get(url).plugins;
+        } else if( this.uniqueUrls.has(url) ){
+                // check if present in global exclude list
+            if ( this.config.edgemicro.plugins && this.config.edgemicro.plugins.excludeUrls && 
+                this.config.edgemicro.plugins.excludeUrls.split(',').indexOf(url) !== -1 ) {
+                return this.defaultPlugins;
+            } else {
+                let urlPlugins = [ ...this.defaultPlugins ];
+                this.plugins.forEach( p => {
+                    if ( p.id === 'quota' && ( !this.config['quotas'] ||
+                        !this.config['quotas'].excludeUrls || this.config['quotas'].excludeUrls.split(',').indexOf(url) === -1 )) {
+                        urlPlugins.push(p);
+                    } else if ( p.id !== 'analytics' && p.id !== 'metrics' &&  ( !this.config[p.id] ||
+                            !this.config[p.id].excludeUrls || this.config[p.id].excludeUrls.split(',').indexOf(url) === -1 ) ) {
+                        urlPlugins.push(p);
+                    }
+                });
+                return urlPlugins;
+            }
+        } else {
+            return this.plugins;
+        }
+        
+    }
+}
+
+module.exports =  PluginsSeqManager;

--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -12,6 +12,7 @@ const errorsLib = require('./errors-middleware')
 const logging = require('./logging')
 const assert = require('assert')
 const configService = require('./config')
+const PluginsSeqManager = require('./PluginsSeqManager')
 
 const CONSOLE_LOG_TAG = 'microgateway-core gateway';
 //http server
@@ -32,7 +33,8 @@ module.exports.start = function(plugins, cb) {
         const logger = logging.getLogger()
 
         const configProxy = configProxyFactory()
-        const pluginsMiddleware = pluginsFactory(plugins)
+        const pluginsSeqManager = new PluginsSeqManager(config, plugins);
+        const pluginsMiddleware = pluginsFactory(pluginsSeqManager)
         const errors = errorsLib(config, logger)
 
         const serverMiddleware = function(req, res) {

--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -22,14 +22,15 @@ var traceHelper = require('./trace-helper');
 
 /**
  * injects plugins into gateway
- * @param plugins
+ * @param pluginsSeqManager
  * @returns {Function(req,res,cb)}
  */
-module.exports = function(plugins) {
+module.exports = function(pluginsSeqManager) {
     const logger = logging.getLogger();
 
     return function(sourceRequest, sourceResponse, next) {
         const startTime = sourceRequest.reqStartTimestamp ||  Date.now();
+        const plugins =  pluginsSeqManager.getPluginSequence(sourceRequest.url);
         const correlation_id = uuid.v1();
         sourceRequest['correlationId'] = correlation_id;
         logger.setTransactionContext( correlation_id,sourceRequest);


### PR DESCRIPTION
Apply only default plugins if 'request url' is present in global excludeUrls.
Skip the plugins whose excludeUrls includes the 'request url'.
Disable caching if 'disableExcUrlsCache' is set to 'true'.

A sample config is:

  plugins:
    excludeUrls: '/hello,/hello/'
    disableExcUrlsCache: true
    sequence:
      - oauth ## used for apikey verification #
      - json2xml
 json2xml:
   excludeUrls: '/hello/help'