### PR TITLE
Abort target server request when client aborts source request, needed…

### DIFF
--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -504,20 +504,21 @@ function _subscribeToResponseEvents(plugins, sourceRequest, sourceResponse, targ
                 if (err) {
                     logger.eventLog({level:'error',req: sourceRequest, res: sourceResponse, err: err,component:'plugins-middleware'});
                 }
-                if (result && result.length) {
-                    sourceResponse.end(result);
-                } else {
-                    sourceResponse.end();
+                if (!sourceResponse.writableFinished) {
+                    if (result && result.length) {
+                        sourceResponse.end(result);
+                    } else {
+                        sourceResponse.end();
+                    }
+                    debug('sourceResponse close', correlation_id, sourceResponse.statusCode);
+                    logger.eventLog({
+                        level:'info',
+                        res: sourceResponse,
+                        req: sourceRequest,
+                        d: Date.now() - sourceRequest.reqStartTimestamp || start,
+                        component:'plugins-middleware'
+                    }, 'sourceResponse' );
                 }
-                debug('sourceResponse close', correlation_id, sourceResponse.statusCode);
-                logger.eventLog({
-                    level:'info',
-                    res: sourceResponse,
-                    req: sourceRequest,
-                    d: Date.now() - sourceRequest.reqStartTimestamp || start,
-                    component:'plugins-middleware'
-                }, 'sourceResponse' );
-
                 return cb(err, result);
             });
     });
@@ -527,6 +528,20 @@ function _subscribeToResponseEvents(plugins, sourceRequest, sourceResponse, targ
         .pipe(sourceResponse, {
             end: false
         });
+
+    sourceResponse.on('close', function(e){
+        if (sourceRequest.aborted) {
+            debug('source request aborted - abort target request', correlation_id);
+            targetRequest.abort();
+            logger.eventLog({
+                level:'info',
+                res: sourceResponse,
+                req: sourceRequest,
+                d: Date.now() - ( sourceRequest.headers['target_sent_start_timestamp'] || targetStartTime ),
+                component:'plugins-middleware'
+            }, 'sourceResponse');
+        }
+    });
 
     targetResponse.on('close', function() {
         debug('targetResponse close', correlation_id);

--- a/tests/target-behavior.js
+++ b/tests/target-behavior.js
@@ -96,6 +96,8 @@ describe('target behavior', () => {
             'proxy' : {
                 'agent' : undefined
             },
+            'on': function(event, cb) {
+            },
             'content-length' : 50
         }
 
@@ -174,6 +176,8 @@ describe('target behavior', () => {
         var sourceResponse = {
             'proxy' : {
                 'agent' : undefined
+            },
+            'on': function(event, cb) {
             },
             'content-length' : 50
         }
@@ -259,6 +263,8 @@ describe('target behavior', () => {
             var sourceResponse = {
                 'proxy' : {
                     'agent' : undefined
+                },
+                'on': function(event, cb) {
                 },
                 'content-length' : 50
             }


### PR DESCRIPTION
… to close connection when using server sent events.

There is a problem when using the microgateway with server sent events since it doesn't close connections with the target server when the client aborts the request.