### PR TITLE
Handle source response close event correctly

### DIFF
--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -299,6 +299,21 @@ function getTargetRequest(sourceRequest, sourceResponse, plugins, startTime, cor
             });
     });
 
+    // abort the target request if the connection from the sourceRequest/sourceResponse is closed.
+    sourceResponse.on('close', function(e){
+        if (sourceRequest.aborted) {
+            debug('source request aborted - abort target request', correlation_id);
+            targetRequest.abort();
+            logger.eventLog({
+                level:'info',
+                res: sourceResponse,
+                req: sourceRequest,
+                d: Date.now() - ( sourceRequest.headers['target_sent_start_timestamp'] || startTime ),
+                component:'plugins-middleware'
+            }, 'sourceResponse on close, source request aborted - abort target request');
+        }
+    });
+
     const logInfo = {
         level: 'info',
         h: sourceRequest.transactionContextData.targetHostName,
@@ -528,20 +543,6 @@ function _subscribeToResponseEvents(plugins, sourceRequest, sourceResponse, targ
         .pipe(sourceResponse, {
             end: false
         });
-
-    sourceResponse.on('close', function(e){
-        if (sourceRequest.aborted) {
-            debug('source request aborted - abort target request', correlation_id);
-            targetRequest.abort();
-            logger.eventLog({
-                level:'info',
-                res: sourceResponse,
-                req: sourceRequest,
-                d: Date.now() - ( sourceRequest.headers['target_sent_start_timestamp'] || targetStartTime ),
-                component:'plugins-middleware'
-            }, 'sourceResponse');
-        }
-    });
 
     targetResponse.on('close', function() {
         debug('targetResponse close', correlation_id);


### PR DESCRIPTION
Register the source response close event when target request is sent instead of registering after response is started to stream from target.