### PR TITLE
Tag plugins sequence to request object

### DIFF
--- a/lib/PluginsSeqManager.js
+++ b/lib/PluginsSeqManager.js
@@ -1,10 +1,13 @@
 const debug = require('debug')('plugins-seq-manager')
 
+const METRICS = 'metrics';
+const ANALYTICS = 'analytics';
 
 class PluginsSeqManager {
 
     constructor(config, plugins){
-        this.plugins = plugins;
+        this.plugins = plugins;        
+        this.gloabalPostflowPlugins = this.getPostflowPluginSequence(this.plugins);
         this.config = config;
         this.urlPluginsCache = new Map();
         this.defaultPlugins = plugins.filter( p => p.id === 'analytics' || p.id === 'metrics');
@@ -33,7 +36,7 @@ class PluginsSeqManager {
             this.config.edgemicro.plugins.excludeUrls.split(',').forEach( url => {
                 this.urlPluginsCache.set(url, {
                     plugins: this.defaultPlugins,
-                    isGlobal: true
+                    postflowPlugins: this.defaultPlugins
                 });
             })
         }
@@ -50,14 +53,16 @@ class PluginsSeqManager {
                     excludeUrls.split(',').forEach( url => {
                             if ( !this.urlPluginsCache.has(url)) {
                                 // skip this plugin
+                                const pluginSequence = this.plugins.filter( plgn => plgn.id !== p.id)
                                 this.urlPluginsCache.set(url, {
-                                    plugins:  this.plugins.filter( plgn => plgn.id !== p.id)
+                                    plugins:  pluginSequence,
+                                    postflowPlugins: this.getPostflowPluginSequence(pluginSequence, url)
                                 });
                             } else {
                                 let value = this.urlPluginsCache.get(url);
-                                this.urlPluginsCache.set(url, {
-                                    plugins:  value.plugins.filter( plgn => plgn.id !== p.id)
-                                });
+                                value.plugins = value.plugins.filter( plgn => plgn.id !== p.id)
+                                value.postflowPlugins = this.getPostflowPluginSequence(value.plugins, url)
+                                this.urlPluginsCache.set(url, value);
                             }
                         }
                     );
@@ -70,16 +75,46 @@ class PluginsSeqManager {
             debug('url: %s, plugins:',url,value.plugins.map(p=>p.id));
         }
     }
+    setPluginSequence(sourceRequest){
+        let pluginsObj = this.getPluginSequence(sourceRequest.url);
+        sourceRequest.preflowPluginSequence = pluginsObj.plugins;
+        sourceRequest.postflowPluginSequence = pluginsObj.postflowPlugins;
+    }
+
+    getPostflowPluginSequence(plugins, url){
+      // calculate the postflow sequence
+      let pluginsReversed = plugins.slice().reverse();
+      if( pluginsReversed && pluginsReversed.length>=2 && 
+          pluginsReversed[pluginsReversed.length-1].id === ANALYTICS &&
+          pluginsReversed[pluginsReversed.length-2].id === METRICS ){
+      
+          let temp = pluginsReversed[pluginsReversed.length-1];
+          //swap position of metrics with analytics plugin.
+          pluginsReversed[pluginsReversed.length-1] = pluginsReversed[pluginsReversed.length-2];
+          pluginsReversed[pluginsReversed.length-2] = temp;
+      }
+      if ( url ) {
+        debug('preflow plugin sequence for url:'+url, plugins.map(p => p.id));
+        debug('postflow plugin sequence for url:'+url, pluginsReversed.map(p => p.id));
+      } else {
+        debug('preflow plugin sequence', plugins.map(p => p.id));
+        debug('postflow plugin sequence', pluginsReversed.map(p => p.id));
+      }
+      return pluginsReversed;
+    }
 
     getPluginSequence(url){
 
         if ( this.urlPluginsCache.has(url) ) {
-            return this.urlPluginsCache.get(url).plugins;
+            return this.urlPluginsCache.get(url);
         } else if( this.uniqueUrls.has(url) ){
                 // check if present in global exclude list
             if ( this.config.edgemicro.plugins && this.config.edgemicro.plugins.excludeUrls && 
                 this.config.edgemicro.plugins.excludeUrls.split(',').indexOf(url) !== -1 ) {
-                return this.defaultPlugins;
+                return {
+                    plugins: this.defaultPlugins,
+                    postflowPlugins: this.defaultPlugins
+                }
             } else {
                 let urlPlugins = [ ...this.defaultPlugins ];
                 this.plugins.forEach( p => {
@@ -91,10 +126,16 @@ class PluginsSeqManager {
                         urlPlugins.push(p);
                     }
                 });
-                return urlPlugins;
+                return {
+                    plugins: urlPlugins,
+                    postflowPlugins: this.getPostflowPluginSequence(urlPlugins, url)
+                }
             }
         } else {
-            return this.plugins;
+            return {
+                plugins: this.plugins,
+                postflowPlugins: this.gloabalPostflowPlugins
+            }
         }
         
     }

--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -18,7 +18,7 @@ const onFinished   = require('on-finished');
 
 //opentracing
 var traceHelper = require('./trace-helper');
-let copyOfPluginsReversed = []; 
+const METRICS = 'metrics';
 //
 
 
@@ -29,27 +29,11 @@ let copyOfPluginsReversed = [];
  */
 module.exports = function(pluginsSeqManager) {
     const logger = logging.getLogger();
-
-    const METRICS = 'metrics';
-    const ANALYTICS = 'analytics';
- 
-    copyOfPluginsReversed = plugins.slice().reverse();
-
-    if(copyOfPluginsReversed && copyOfPluginsReversed.length>=2 && 
-    copyOfPluginsReversed[copyOfPluginsReversed.length-1].id === ANALYTICS &&
-    copyOfPluginsReversed[copyOfPluginsReversed.length-2].id === METRICS){
     
-    let temp = copyOfPluginsReversed[copyOfPluginsReversed.length-1];
-    //swap position of metrics with analytics plugin.
-    copyOfPluginsReversed[copyOfPluginsReversed.length-1] = copyOfPluginsReversed[copyOfPluginsReversed.length-2];
-    copyOfPluginsReversed[copyOfPluginsReversed.length-2] = temp;
-    }
-    debug('Plugin sequence', plugins.map(p => p.id));
-    debug('Reversed plugin sequence', copyOfPluginsReversed.map(p => p.id));
-
     return function(sourceRequest, sourceResponse, next) {
         const startTime = sourceRequest.reqStartTimestamp ||  Date.now();
-        const plugins =  pluginsSeqManager.getPluginSequence(sourceRequest.url);
+        pluginsSeqManager.setPluginSequence(sourceRequest);
+        const plugins =  sourceRequest.preflowPluginSequence;
         const correlation_id = uuid.v1();
         sourceRequest['correlationId'] = correlation_id;
         logger.setTransactionContext( correlation_id,sourceRequest);
@@ -72,7 +56,7 @@ module.exports = function(pluginsSeqManager) {
             //opentracing
             traceHelper.setRequestError('','header length more than allowed size','', 400);
             // on failed condition maxHttpHeaderSize, sending metrics data to master node. 
-            if(copyOfPluginsReversed && copyOfPluginsReversed[copyOfPluginsReversed.length-1].id === METRICS){
+            if(plugins && plugins[plugins.length-1].id === METRICS){
                 makeMetricsRecord(sourceRequest, sourceResponse);
             }
             return next(false);
@@ -384,7 +368,7 @@ function getTargetRequest(sourceRequest, sourceResponse, plugins, startTime, cor
 function handleTargetResponse(targetRequest, targetResponse, options, cb) {
     const start = options.targetStartTime;
     const correlation_id = options.correlation_id;
-    const plugins = copyOfPluginsReversed;
+    const plugins = options.sourceRequest.postflowPluginSequence;
     const sourceRequest = options.sourceRequest;
     const sourceResponse = options.sourceResponse;
     const logger = logging.getLogger();


### PR DESCRIPTION
Calculate preflow plugin sequence and postflow plugin sequence in PluginsSeqManager.
Set 'preflowPluginSequence' and 'postflowPluginSequence' on 'sourceRequest' object.
Use 'sourceRequest.preflowPluginSequence' and 'sourceRequest.postflowPluginSequence' in plugins-middleware.