### PR TITLE
179971737 Capture target status code in analytics

### DIFF
--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -381,6 +381,8 @@ function handleTargetResponse(targetRequest, targetResponse, options, cb) {
     const logger = logging.getLogger();
     const config = configService.get();
 
+    sourceRequest.headers['target_response_code'] = targetResponse.statusCode;
+
     debug('targetResponse', correlation_id, targetResponse.statusCode);
     async.series(
         //onresponse


### PR DESCRIPTION
Set 'target_response_code' property on req object because analytics plugin needs this data