### PR TITLE
179366445 Add support for GET requests with body

### DIFF
--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -235,7 +235,7 @@ function getTargetRequest(sourceRequest, sourceResponse, plugins, startTime, cor
 
         if (target_headers['content-length']) {
             delete target_headers['content-length'];
-            if(!target_headers['transfer-encoding'] && sourceRequest.method==='DELETE') {
+            if(!target_headers['transfer-encoding'] && (sourceRequest.method==='DELETE' || sourceRequest.method==='GET')) {
                 target_headers['transfer-encoding'] = 'chunked';
             }
         }
@@ -499,7 +499,7 @@ function subscribeToSourceRequestEvents(plugins, sourceRequest, sourceResponse, 
             });
     });
 
-    if ( (targetRequest.method === "GET") || (targetRequest.method === "HEAD") ) {
+    if (targetRequest.method === "HEAD") {
         targetRequest._hasBody = false;
     }
 


### PR DESCRIPTION
  Added request header ‘transfer-encoding’ with value as ‘chunked’ for source request method as GET
  Set ‘_hasBody’ property of target request to allow body for ‘GET method requests’