### PR TITLE
179366445 Make support for GET requests with body configurable

### DIFF
--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -235,7 +235,7 @@ function getTargetRequest(sourceRequest, sourceResponse, plugins, startTime, cor
 
         if (target_headers['content-length']) {
             delete target_headers['content-length'];
-            if(!target_headers['transfer-encoding'] && (sourceRequest.method==='DELETE' || sourceRequest.method==='GET')) {
+            if(!target_headers['transfer-encoding'] && (sourceRequest.method==='DELETE' || (sourceRequest.method==='GET' && config.edgemicro.enable_GET_req_body))) {
                 target_headers['transfer-encoding'] = 'chunked';
             }
         }
@@ -468,6 +468,7 @@ function handleTargetResponse(targetRequest, targetResponse, options, cb) {
  */
 function subscribeToSourceRequestEvents(plugins, sourceRequest, sourceResponse, targetRequest) {
     const logger = logging.getLogger();
+    const config = configService.get();
 
     // using apply on the array returned by getPluginHooksForEvent --> using a dummy object in place of this, which cannot be bound here.
     const onend_request_handlers = async.seq.apply({}, getPluginHooksForEvent('end', {
@@ -501,7 +502,7 @@ function subscribeToSourceRequestEvents(plugins, sourceRequest, sourceResponse, 
             });
     });
 
-    if (targetRequest.method === "HEAD") {
+    if ((targetRequest.method==='GET' && !config.edgemicro.enable_GET_req_body) || (targetRequest.method === "HEAD")) {
         targetRequest._hasBody = false;
     }
 


### PR DESCRIPTION
Added consideration for new config variable 'enable_GET_req_body' which is optional
Set request header ‘transfer-encoding’ with value as ‘chunked’ only if with source request method as GET the config enable_GET_req_body is also specified with value as true
Set ‘_hasBody’ property of target request to true  to allow body(for GET requests) only if with request method as GET the config enable_GET_req_body is also specified with value as true