### PR TITLE
192416584 Make permissions for log file configurable

### DIFF
--- a/lib/logging.js
+++ b/lib/logging.js
@@ -67,7 +67,11 @@ module.exports.init = function init(stubConfig, options) {
       }
     }
       try {
-        logFileFd = fs.openSync(logFilePath, 'a', 0o0600);
+        if(logConfig.disableStrictLogFile){
+          logFileFd = fs.openSync(logFilePath, 'a', 0o0755);
+         }else{
+          logFileFd = fs.openSync(logFilePath, 'a', 0o0600);
+         }
       } catch (e) {
         if ( !logFileOpenFailWarn ) {
           writeConsoleLog('log',{component: CONSOLE_LOG_TAG}, 'Error in creating log file: %s, error: %s',logFilePath, e.message);


### PR DESCRIPTION
  Optimised code to support new config “disableStrictLogFile” to change the permission of log file.
  Permission of the log file will be set to 0755 if “disableStrictLogFile” config is set to true.
  Default value will be the same as earlier that is 0600 if the config is not mentioned or set to anything other than true.