### PR TITLE
138414116 Add test case for target request error

### DIFF
--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -303,7 +303,7 @@ function getTargetRequest(sourceRequest, sourceResponse, plugins, startTime, cor
             sourceResponse.statusCode = gatewayBadErrCode; // Bad Gateway
         }
 
-        logger.eventLog({level:'warn',
+        logger.eventLog({level:'error',
             d: Date.now() - startTime,
             err: err,
             h: sourceRequest.transactionContextData.targetHostName,

--- a/tests/proxy-tests.js
+++ b/tests/proxy-tests.js
@@ -91,6 +91,26 @@ const startGateway = (config, handler, done) => {
       done()
     }); 
     
+    const sockets = new Set();
+
+    server.on('connection', (socket) => {
+      sockets.add(socket);
+      server.once('close', () => {
+        sockets.delete(socket);
+      });
+    });
+  
+    /**
+     * Forcefully terminates HTTP server.
+     */
+    server.forceClose = (callback) => {
+      for (const socket of sockets) {
+        socket.destroy();
+        sockets.delete(socket);
+      }
+      server.close(callback);
+    };
+
   })
 }
 
@@ -410,4 +430,102 @@ describe('test configuration handling', () => {
 
     })
   })
+
+  describe('Verify proxy response behaviour', () => {
+    it('will verify ECONNRESET socket hang up scenario', (done) => {
+      const baseConfig = {
+        edgemicro: {
+          port: gatewayPort,
+          logging: { level: 'info', dir: './tests/log' }
+        },
+        proxies: [
+          { base_path: '/mocktarget', secure: false, url: `http://localhost:${port}` }
+        ]
+      }
+  
+      startGateway(baseConfig, (req, res) => {
+        server.forceClose();
+        res.end('OK')
+      }, () => {
+        gateway.start((err) => {
+          assert.ok(!err, err);
+          request(`http://localhost:${gatewayPort}/mocktarget/abrupted-response`, function (error, response, body) {
+            assert.strictEqual(response.statusCode, 502);
+            assert.match(body, new RegExp('ECONNRESET'));
+            done();
+          });
+        })
+      });
+    });
+  
+    it('will verify ENOTFOUND wrong target scenario', (done) => {
+      const baseConfig = {
+        edgemicro: {
+          port: gatewayPort,
+          logging: { level: 'info', dir: './tests/log' }
+        },
+        proxies: [
+          { base_path: '/mocktarget', secure: false, url: `http://wrong-target:${port}` }
+        ]
+      }
+  
+      startGateway(baseConfig, (req, res) => {
+        res.end('ok');
+      }, () => {
+        gateway.start((err) => {
+          assert.ok(!err, err);
+          request(`http://localhost:${gatewayPort}/mocktarget/abrupted-response`, function (error, response, body) {
+            assert.match(body, new RegExp('ENOTFOUND'));
+            assert.strictEqual(response.statusCode, 502)
+            done();
+          });
+        })
+      });
+    });
+  
+    it('will verify target response matches the source response', (done) => {
+      const requestPromise = util.promisify(request);
+  
+      const baseConfig = {
+        edgemicro: {
+          port: gatewayPort,
+          logging: { level: 'info', dir: './tests/log' }
+        },
+        proxies: [
+          { base_path: '/mocktarget', secure: false, url: 'http://mocktarget.apigee.net/' }
+        ]
+      }
+  
+      startGateway(baseConfig, (req, res) => {
+        res.end('OK')
+      }, () => {
+        gateway.start(async (err) => {
+          assert.ok(!err, err);
+  
+          var response = await requestPromise({ method: 'GET', url: 'http://localhost:' + gatewayPort + `/mocktarget/statuscode/200` });
+          assert.strictEqual(response.statusCode, 200)
+  
+          var response = await requestPromise({ method: 'GET', url: 'http://localhost:' + gatewayPort + `/mocktarget/statuscode/300` });
+          assert.strictEqual(response.statusCode, 300)
+  
+          var response = await requestPromise({ method: 'GET', url: 'http://localhost:' + gatewayPort + `/mocktarget/statuscode/400` });
+          assert.strictEqual(response.statusCode, 400)
+  
+          var response = await requestPromise({ method: 'GET', url: 'http://localhost:' + gatewayPort + `/mocktarget/statuscode/500` });
+          assert.strictEqual(response.statusCode, 500)
+  
+          var response = await requestPromise({ method: 'GET', url: 'http://localhost:' + gatewayPort + `/mocktarget/statuscode/501` });
+          assert.strictEqual(response.statusCode, 501)
+  
+          var response = await requestPromise({ method: 'GET', url: 'http://localhost:' + gatewayPort + `/mocktarget/statuscode/503` });
+          assert.strictEqual(response.statusCode, 503)
+  
+          var response = await requestPromise({ method: 'GET', url: 'http://localhost:' + gatewayPort + `/mocktarget/statuscode/505` });
+          assert.strictEqual(response.statusCode, 505)
+  
+          done();
+        })
+      });
+    });
+  });
 })


### PR DESCRIPTION
  Change log level to from 'warn' to 'error' on target request 'error' event log
  Add test cases to verify response behaviour in case of target request error