### PR TITLE
192534424 Fix the status code when request is aborted

### DIFF
--- a/lib/plugins-middleware.js
+++ b/lib/plugins-middleware.js
@@ -21,6 +21,7 @@ var traceHelper = require('./trace-helper');
 const METRICS = 'metrics';
 //
 
+const clientClosedRequestErrCode = 499;
 
 /**
  * injects plugins into gateway
@@ -88,6 +89,11 @@ module.exports = function(pluginsSeqManager) {
                             sendMetricsData(sourceRequest.headers['metrics_record']);
                         }
                         return next(err)
+                    }
+                    if (sourceRequest.aborted) {
+                        sourceResponse.statusCode = clientClosedRequestErrCode;
+                        const err = new Error("source request aborted");
+                        return next(err);
                     }
                     //opentrace
                     traceHelper.startTargetSpan(correlation_id, sourceRequest.targetHostname);
@@ -344,6 +350,7 @@ function getTargetRequest(sourceRequest, sourceResponse, plugins, startTime, cor
     sourceResponse.on('close', function(e){
         if (sourceRequest.aborted) {
             debug('source request aborted - abort target request', correlation_id);
+            sourceResponse.statusCode = clientClosedRequestErrCode;
             targetRequest.abort();
             logger.eventLog({
                 level:'info',
@@ -413,7 +420,8 @@ function handleTargetResponse(targetRequest, targetResponse, options, cb) {
             }, 'targetResponse');
 
             if ( err ) logger.eventLog({level:'error', req: sourceRequest, res: sourceResponse, err: err,component:'plugins-middleware'},"");
-            if (sourceResponse.finished || sourceResponse.headersSent) {
+            if (sourceResponse.finished || sourceResponse.headersSent || sourceRequest.aborted) {
+                sourceResponse.statusCode = clientClosedRequestErrCode;
                 logger.eventLog({level:'error',req: sourceRequest, res: sourceResponse, err: err,component:'plugins-middleware'},"response finished before work can be done");
                 return;
             }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "async": "~1.5.2",
     "debug": "~3.1.0",
     "lodash": "^4.17.19",
-    "microgateway-config": "^3.2.3",
+    "microgateway-config": "apigee/microgateway-config#for-3.2.4",
     "minimatch": "^3.0.4",
     "opentracing": "^0.14.3",
     "request": "~2.87.0",


### PR DESCRIPTION
  Added condition to check if the source request is aborted and
  update the status code for response, event logs and analytics with
  HTTP status code 499 if the request is aborted at any given point.